### PR TITLE
💄 style: redesign xdanger.com — editorial overhaul

### DIFF
--- a/src/components/AboutMe.astro
+++ b/src/components/AboutMe.astro
@@ -1,47 +1,33 @@
 ---
 import SocialList from "@/components/SocialList.astro";
-import { siteConfig } from "@/site.config";
 import { Icon } from "astro-icon/components";
-
-interface Props {
-  // Render the name/tagline hero. Off on pages that already have their own <h1>.
-  showIntro?: boolean;
-}
-
-const { showIntro = true } = Astro.props;
 ---
 
-<div>
-  {
-    showIntro && (
-      <header class="mb-8">
-        <h1 class="text-accent-2 text-3xl font-semibold sm:text-4xl">{siteConfig.author}</h1>
-        <p class="mt-2 text-gray-600 dark:text-gray-400">Notes on tech, products, and life.</p>
-      </header>
-    )
-  }
-  <ul class="list-none space-y-3 ps-0 leading-relaxed">
-    <li class="ps-0">
-      <Icon name="solar:chef-hat-heart-line-duotone" class="mr-2 inline-block h-5 w-5" />a father
-    </li>
-    <li class="ps-0">
-      <Icon name="solar:code-bold-duotone" class="mr-2 inline-block h-5 w-5" />like coding
-    </li>
-    <li class="ps-0">
-      <Icon name="solar:gamepad-line-duotone" class="mr-2 inline-block h-5 w-5" />presently as ceo
-      of <a class="cactus-link" href="https://www.taptap.com/">TapTap</a>, co-founder of <a
-        class="cactus-link"
+<ul class="iam">
+  <li>
+    <span class="glyph"><Icon name="solar:chef-hat-heart-line-duotone" aria-hidden="true" /></span>
+    <span>a father</span>
+  </li>
+  <li>
+    <span class="glyph"><Icon name="solar:code-bold-duotone" aria-hidden="true" /></span>
+    <span>like coding</span>
+  </li>
+  <li>
+    <span class="glyph"><Icon name="solar:gamepad-line-duotone" aria-hidden="true" /></span>
+    <span
+      >presently ceo of <a href="https://www.taptap.com/">TapTap</a>, co-founder of <a
         href="https://www.xd.com/">XD Inc</a
-      >
-    </li>
-    <li class="ps-0">
-      <Icon
-        name="solar:turntable-music-note-line-duotone"
-        class="mr-2 inline-block h-5 w-5"
-      />previously as co-founder of <a class="cactus-link" href="https://www.verycd.com/">VeryCD</a>
-    </li>
-  </ul>
-  <div class="mt-3">
-    <SocialList />
-  </div>
-</div>
+      ></span
+    >
+  </li>
+  <li>
+    <span class="glyph"
+      ><Icon name="solar:turntable-music-note-line-duotone" aria-hidden="true" /></span
+    >
+    <span>previously co-founder of <a href="https://www.verycd.com/">VeryCD</a></span>
+  </li>
+  <li>
+    <span class="glyph" aria-hidden="true">@</span>
+    <span>find <span class="handle">xdanger</span> on <SocialList /></span>
+  </li>
+</ul>

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -82,13 +82,13 @@ const socialImageURL = new URL(ogImage ? ogImage : "/social-card.png", Astro.url
 <link href="/notes/rss.xml" title="Notes" rel="alternate" type="application/rss+xml" />
 
 {/* Fonts */}
-<!-- <Font cssVariable="--font-ia-writer-duo" preload /> -->
+{/* UI / chrome — monospace */}
 <Font cssVariable="--font-ia-writer-mono" preload />
-{/* Latin serif for prose body text; CJK falls through to LXGW WenKai Lite */}
+{/* Body / prose — sans (Latin); CJK falls through to the system sans stack */}
+<Font cssVariable="--font-geist" preload />
+{/* Display headlines — serif (Latin); CJK display uses LXGW WenKai Lite */}
 <Font cssVariable="--font-newsreader" />
-<!-- <Font cssVariable="--font-geist" preload />
-<Font cssVariable="--font-geist-mono" preload /> -->
-{/* LXGW WenKai Lite (CJK serif) served from jsDelivr; family: "LXGW WenKai Lite" */}
+{/* LXGW WenKai Lite (CJK display) served from jsDelivr; family: "LXGW WenKai Lite" */}
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
 <link
   rel="stylesheet"

--- a/src/components/Paginator.astro
+++ b/src/components/Paginator.astro
@@ -11,17 +11,17 @@ const { nextUrl, prevUrl } = Astro.props;
 
 {
   (prevUrl || nextUrl) && (
-    <nav class="mt-8 flex items-center gap-x-4">
+    <nav class="paginator" aria-label="Pagination">
       {prevUrl && (
-        <a class="hover:text-accent me-auto py-2" data-astro-prefetch href={prevUrl.url}>
-          {prevUrl.srLabel && <span class="sr-only">{prevUrl.srLabel}</span>}
-          {prevUrl.text ? prevUrl.text : "Previous"}
+        <a class="paginator__prev" data-astro-prefetch href={prevUrl.url}>
+          {prevUrl.srLabel && <span class="sr-only">{prevUrl.srLabel}</span>}←{" "}
+          {prevUrl.text ?? "Newer"}
         </a>
       )}
       {nextUrl && (
-        <a class="hover:text-accent ms-auto py-2" data-astro-prefetch href={nextUrl.url}>
+        <a class="paginator__next" data-astro-prefetch href={nextUrl.url}>
           {nextUrl.srLabel && <span class="sr-only">{nextUrl.srLabel}</span>}
-          {nextUrl.text ? nextUrl.text : "Next"}
+          {nextUrl.text ?? "Older"} →
         </a>
       )}
     </nav>

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -1,35 +1,30 @@
 ---
 // Heavy inspiration taken from Astro Starlight -> https://github.com/withastro/starlight/blob/main/packages/starlight/components/Search.astro
-
 import "@/styles/blocks/search.css";
 import { Icon } from "astro-icon/components";
 ---
 
-<site-search class="h-5 w-5" id="search">
+<site-search id="search">
   <button
-    class="hover:text-accent flex cursor-pointer justify-center rounded-md"
-    aria-keyshortcuts="Control+K Meta+K"
+    class="search-btn"
+    aria-keyshortcuts="Control+K Meta+K /"
+    aria-label="Search"
     data-open-modal
     disabled
   >
-    <Icon name="solar:magnifer-linear" class="h-5 w-5" />
-    <span class="sr-only">Open Search</span>
+    <Icon name="solar:magnifer-linear" aria-hidden="true" focusable="false" />
+    <span class="skb">Search</span>
+    <kbd aria-hidden="true">/</kbd>
   </button>
-  <dialog
-    aria-label="search"
-    class="bg-global-bg h-full max-h-full w-full max-w-full border border-zinc-400 shadow-sm backdrop:backdrop-blur-sm open:flex sm:mx-auto sm:mt-16 sm:mb-auto sm:h-max sm:max-h-[calc(100%-8rem)] sm:min-h-[15rem] sm:w-5/6 sm:max-w-[48rem] sm:rounded-md"
-  >
-    <div class="dialog-frame flex grow flex-col gap-4 p-6 pt-12 sm:pt-6">
-      <button
-        class="ms-auto cursor-pointer rounded-md bg-zinc-200 p-2 font-semibold dark:bg-zinc-700"
-        data-close-modal>Close</button
-      >
+  <dialog aria-label="Search" class="search-dialog">
+    <div class="dialog-frame">
+      <button class="search-close" data-close-modal aria-label="Close search">Esc</button>
       {
         import.meta.env.DEV ? (
-          <div class="mx-auto text-center">
+          <div class="search-dev-note">
             <p>
-              Search is only available in production builds. <br />
-              Try building and previewing the site to test it out locally.
+              Search is only available in production builds. Build and preview the site to test it
+              locally.
             </p>
           </div>
         ) : (
@@ -58,7 +53,6 @@ import { Icon } from "astro-icon/components";
       this.#dialogFrame = this.querySelector(".dialog-frame");
       this.#controller = new AbortController();
 
-      // Set up events
       if (this.#openBtn) {
         this.#openBtn.addEventListener("click", this.openModal);
         this.#openBtn.disabled = false;
@@ -68,16 +62,12 @@ import { Icon } from "astro-icon/components";
 
       if (this.#closeBtn) {
         this.#closeBtn.addEventListener("click", this.closeModal);
-      } else {
-        console.warn("Close button not found");
       }
 
       if (this.#dialog) {
         this.#dialog.addEventListener("close", () => {
           window.removeEventListener("click", this.onWindowClick);
         });
-      } else {
-        console.warn("Dialog not found");
       }
 
       // only add pagefind in production
@@ -93,7 +83,6 @@ import { Icon } from "astro-icon/components";
           showSubResults: true,
           processTerm: (term: string) => term,
           processResult: (result: { url: string }) => {
-            // 移除结果 URL 的尾部斜杠
             if (result.url && result.url.endsWith("/")) {
               result.url = result.url.slice(0, -1);
             }
@@ -104,7 +93,6 @@ import { Icon } from "astro-icon/components";
     }
 
     connectedCallback() {
-      // window events, requires cleanup
       window.addEventListener("keydown", this.onWindowKeydown, { signal: this.#controller.signal });
     }
 
@@ -113,11 +101,7 @@ import { Icon } from "astro-icon/components";
     }
 
     openModal = (event?: MouseEvent) => {
-      if (!this.#dialog) {
-        console.warn("Dialog not found");
-        return;
-      }
-
+      if (!this.#dialog) return;
       this.#dialog.showModal();
       this.querySelector("input")?.focus();
       event?.stopPropagation();
@@ -127,9 +111,7 @@ import { Icon } from "astro-icon/components";
     closeModal = () => this.#dialog?.close();
 
     onWindowClick = (event: MouseEvent) => {
-      // check if it's a link
       const isLink = "href" in (event.target || {});
-      // make sure the click is either a link or outside of the dialog
       if (
         isLink ||
         (document.body.contains(event.target as Node) &&
@@ -140,14 +122,23 @@ import { Icon } from "astro-icon/components";
     };
 
     onWindowKeydown = (e: KeyboardEvent) => {
-      if (!this.#dialog) {
-        console.warn("Dialog not found");
-        return;
-      }
-      // check if it's the Control+K or ⌘+K shortcut
-      if ((e.metaKey === true || e.ctrlKey === true) && e.key === "k") {
+      if (!this.#dialog) return;
+      // Control/⌘ + K
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         this.#dialog.open ? this.closeModal() : this.openModal();
         e.preventDefault();
+        return;
+      }
+      // "/" to open, unless typing in a field
+      if (e.key === "/" && !this.#dialog.open) {
+        const el = e.target as HTMLElement | null;
+        const typing =
+          el &&
+          (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable === true);
+        if (!typing) {
+          this.openModal();
+          e.preventDefault();
+        }
       }
     };
   }

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -123,8 +123,8 @@ import { Icon } from "astro-icon/components";
 
     onWindowKeydown = (e: KeyboardEvent) => {
       if (!this.#dialog) return;
-      // Control/⌘ + K
-      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      // Control/⌘ + K (normalize case so Shift/Caps Lock still matches)
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         this.#dialog.open ? this.closeModal() : this.openModal();
         e.preventDefault();
         return;

--- a/src/components/SocialList.astro
+++ b/src/components/SocialList.astro
@@ -1,58 +1,19 @@
 ---
 import { Icon } from "astro-icon/components";
 
-/**
-	Uses https://www.astroicon.dev/getting-started/
-	Find icons via guide: https://www.astroicon.dev/guides/customization/#open-source-icon-sets
-	Only installed pack is: @iconify-json/mdi
-*/
-const socialLinks: {
-  friendlyName: string;
-  isWebmention?: boolean;
-  link: string;
-  icon: string;
-}[] = [
-  {
-    friendlyName: "X",
-    link: "https://x.com/xdanger",
-    icon: "fa6-brands:square-x-twitter",
-  },
-  {
-    friendlyName: "Github",
-    link: "https://github.com/xdanger",
-    icon: "mdi:github",
-  },
-
-  {
-    friendlyName: "Instagram",
-    link: "https://www.instagram.com/xdanger",
-    icon: "mdi:instagram",
-  },
+const socialLinks: { friendlyName: string; link: string; icon: string }[] = [
+  { friendlyName: "X", link: "https://x.com/xdanger", icon: "fa6-brands:square-x-twitter" },
+  { friendlyName: "GitHub", link: "https://github.com/xdanger", icon: "mdi:github" },
+  { friendlyName: "Instagram", link: "https://www.instagram.com/xdanger", icon: "mdi:instagram" },
 ];
 ---
 
-<div class="flex flex-wrap items-end">
-  <p>find <code class="text-accent">xdanger</code> on</p>
-  <ul class="flex flex-1 items-center gap-x-2 ps-2 sm:flex-initial">
-    {
-      socialLinks.map(({ friendlyName, isWebmention, link, icon }) => (
-        <li class="flex">
-          <a
-            class="hover:text-link inline-block"
-            href={link}
-            rel={`noreferrer ${isWebmention ? "me authn" : ""}`}
-            target="_blank"
-          >
-            <Icon
-              aria-hidden="true"
-              class="h-5 w-5 fill-current text-gray-700 dark:text-gray-300"
-              focusable="false"
-              name={icon}
-            />
-            <span class="sr-only">{friendlyName}</span>
-          </a>
-        </li>
-      ))
-    }
-  </ul>
-</div>
+<span class="socials">
+  {
+    socialLinks.map(({ friendlyName, link, icon }) => (
+      <a href={link} rel="noreferrer me" target="_blank" aria-label={friendlyName}>
+        <Icon name={icon} aria-hidden="true" focusable="false" />
+      </a>
+    ))
+  }
+</span>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -2,51 +2,34 @@
 import { Icon } from "astro-icon/components";
 ---
 
-<theme-toggle class="flex flex-col">
-  <button class="hover:text-accent cursor-pointer rounded-md pr-4" type="button">
-    <span class="sr-only">Dark Theme</span>
-    <Icon
-      name="solar:sun-linear"
-      class="absolute h-5 w-5 scale-100 opacity-100 transition-all dark:scale-0 dark:opacity-0"
-    />
-    <Icon
-      name="solar:moon-linear"
-      class="absolute h-5 w-5 scale-0 opacity-0 transition-all dark:scale-100 dark:opacity-100"
-    />
+<theme-toggle>
+  <button class="icon-btn theme-toggle" type="button" aria-label="Toggle color theme">
+    <Icon name="solar:sun-linear" class="sun" aria-hidden="true" />
+    <Icon name="solar:moon-linear" class="moon" aria-hidden="true" />
   </button>
 </theme-toggle>
 
 <script>
-  // Note that if you fire the theme-change event outside of this component, it will not be reflected in the button's aria-checked attribute. You will need to add an event listener if you want that.
   import { rootInDarkMode } from "@/utils/domElement";
 
   class ThemeToggle extends HTMLElement {
     constructor() {
       super();
       const button = this.querySelector<HTMLButtonElement>("button");
-
-      if (button) {
-        // set aria role value
-        button.setAttribute("role", "switch");
-        button.setAttribute("aria-checked", String(rootInDarkMode()));
-
-        // button event
-        button.addEventListener("click", () => {
-          // invert theme
-          const themeChangeEvent = new CustomEvent("theme-change", {
-            detail: {
-              theme: rootInDarkMode() ? "light" : "dark",
-            },
-          });
-          // dispatch event -> ThemeProvider.astro
-          document.dispatchEvent(themeChangeEvent);
-
-          // set the aria-checked attribute
-          button.setAttribute("aria-checked", String(rootInDarkMode()));
-        });
-      } else {
+      if (!button) {
         console.warn("Theme Toggle: No button found");
+        return;
       }
+      button.setAttribute("role", "switch");
+      button.setAttribute("aria-checked", String(rootInDarkMode()));
+      button.addEventListener("click", () => {
+        document.dispatchEvent(
+          new CustomEvent("theme-change", {
+            detail: { theme: rootInDarkMode() ? "light" : "dark" },
+          }),
+        );
+        button.setAttribute("aria-checked", String(rootInDarkMode()));
+      });
     }
   }
 

--- a/src/components/blog/Masthead.astro
+++ b/src/components/blog/Masthead.astro
@@ -41,7 +41,11 @@ const dateOptions: Intl.DateTimeFormatOptions = {
             ·
           </span>
           {data.tags.map((tag) => (
-            <a class="tag-chip" href={`/tags/${tag}`} data-pagefind-filter={`tag:${tag}`}>
+            <a
+              class="tag-chip"
+              href={`/tags/${encodeURIComponent(tag)}`}
+              data-pagefind-filter={`tag:${tag}`}
+            >
               {tag}
             </a>
           ))}

--- a/src/components/blog/Masthead.astro
+++ b/src/components/blog/Masthead.astro
@@ -13,71 +13,64 @@ const {
   readingTime,
 } = Astro.props;
 
-const dateTimeOptions: Intl.DateTimeFormatOptions = {
-  month: "long",
+const dateOptions: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "2-digit",
 };
 ---
 
-{
-  data.coverImage && (
-    <div class="mb-6 aspect-video">
-      <Image
-        alt={data.coverImage.alt}
-        class="object-cover"
-        fetchpriority="high"
-        loading="eager"
-        src={data.coverImage.src as unknown as ImageMetadata}
-      />
-    </div>
-  )
-}
-{data.draft ? <span class="text-base text-red-500">(Draft)</span> : null}
-<h1 class="title my-10">
-  {data.title}
-</h1>
-<div class="flex flex-wrap items-center gap-x-3 gap-y-2">
-  <p class="font-semibold">
-    <FormattedDate date={data.publishDate} dateTimeOptions={dateTimeOptions} /> /{" "}
-    {readingTime}
-  </p>
+<header class="article-header">
+  <a href="/posts" class="backlink">← Back to blog</a>
   {
-    data.updatedDate && (
-      <span class="bg-quote/5 text-quote rounded-lg px-2 py-1">
-        Updated:
-        <FormattedDate class="ms-1" date={data.updatedDate} dateTimeOptions={dateTimeOptions} />
-      </span>
+    data.draft && (
+      <p class="leader__draft" style="font-family: var(--font-mono)">
+        (draft)
+      </p>
     )
   }
-</div>
-{
-  !!data.tags?.length && (
-    <div class="mt-2">
-      <svg
-        aria-hidden="true"
-        class="inline-block h-6 w-6"
-        fill="none"
-        focusable="false"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="1.5"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path d="M0 0h24v24H0z" fill="none" stroke="none" />
-        <path d="M7.859 6h-2.834a2.025 2.025 0 0 0 -2.025 2.025v2.834c0 .537 .213 1.052 .593 1.432l6.116 6.116a2.025 2.025 0 0 0 2.864 0l2.834 -2.834a2.025 2.025 0 0 0 0 -2.864l-6.117 -6.116a2.025 2.025 0 0 0 -1.431 -.593z" />
-        <path d="M17.573 18.407l2.834 -2.834a2.025 2.025 0 0 0 0 -2.864l-7.117 -7.116" />
-        <path d="M6 9h-.01" />
-      </svg>
-      {data.tags.map((tag, i) => (
+  <h1 class="article-title">{data.title}</h1>
+  <div class="article-meta">
+    <FormattedDate date={data.publishDate} dateTimeOptions={dateOptions} />
+    <span class="dot" aria-hidden="true">·</span>
+    <span>{readingTime}</span>
+    {
+      data.tags.length > 0 && (
         <>
-          {/* prettier-ignore */}
-          <span class="contents">
-						<a class="cactus-link inline-block before:content-['#']" data-pagefind-filter={`tag:${tag}`} href={`/tags/${tag}`}><span class="sr-only">View more blogs with the tag&nbsp;</span>{tag}
-						</a>{i < data.tags.length - 1 && ", "}
-					</span>
+          <span class="dot" aria-hidden="true">
+            ·
+          </span>
+          {data.tags.map((tag) => (
+            <a class="tag-chip" href={`/tags/${tag}`} data-pagefind-filter={`tag:${tag}`}>
+              {tag}
+            </a>
+          ))}
         </>
-      ))}
-    </div>
-  )
-}
+      )
+    }
+    {
+      data.updatedDate && (
+        <>
+          <span class="dot" aria-hidden="true">
+            ·
+          </span>
+          <span class="article-updated">
+            updated <FormattedDate date={data.updatedDate} dateTimeOptions={dateOptions} />
+          </span>
+        </>
+      )
+    }
+  </div>
+  {
+    data.coverImage && (
+      <figure class="article-cover">
+        <Image
+          alt={data.coverImage.alt}
+          fetchpriority="high"
+          loading="eager"
+          src={data.coverImage.src as unknown as ImageMetadata}
+        />
+      </figure>
+    )
+  }
+</header>

--- a/src/components/blog/PostPreview.astro
+++ b/src/components/blog/PostPreview.astro
@@ -2,25 +2,24 @@
 import type { CollectionEntry } from "astro:content";
 import FormattedDate from "@/components/FormattedDate.astro";
 import { getPostPath } from "@/utils/url";
-import type { HTMLTag, Polymorphic } from "astro/types";
 
-type Props<Tag extends HTMLTag> = Polymorphic<{ as: Tag }> & {
+interface Props {
   post: CollectionEntry<"post">;
-  withDesc?: boolean;
-};
+  /** drop the year (used inside year-grouped lists) */
+  compactDate?: boolean;
+}
 
-const { as: Tag = "div", post, withDesc = false } = Astro.props;
+const { post, compactDate = false } = Astro.props;
 const postUrl = getPostPath(post);
+const dateOptions: Intl.DateTimeFormatOptions | undefined = compactDate
+  ? { year: undefined, month: "short", day: "2-digit" }
+  : undefined;
 ---
 
-<FormattedDate
-  class="min-w-30 font-normal text-gray-600 dark:text-gray-400"
-  date={post.data.publishDate}
-/>
-<Tag>
-  {post.data.draft && <span class="text-red-500">(Draft) </span>}
-  <a class="cactus-link" data-astro-prefetch href={postUrl}>
-    {post.data.title}
+<span class="leader">
+  <a class="leader__title" data-astro-prefetch href={postUrl}>
+    {post.data.draft && <span class="leader__draft">(draft) </span>}{post.data.title}
   </a>
-</Tag>
-{withDesc && <q class="line-clamp-3 italic">{post.data.description}</q>}
+  <span class="leader__dots" aria-hidden="true"></span>
+  <FormattedDate class="leader__date" date={post.data.publishDate} dateTimeOptions={dateOptions} />
+</span>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,17 +1,17 @@
 ---
 import { siteConfig } from "@/site.config";
+import { Icon } from "astro-icon/components";
 
 const year = new Date().getFullYear();
 ---
 
-<footer class="flex min-h-15 flex-col border-t border-dashed border-gray-200 dark:border-gray-700">
-  <div class="relative container m-auto max-w-4xl p-4 sm:flex-col sm:px-6">
-    <div class="me-0 sm:me-4">
-      &copy; {siteConfig.author}
-      {year}. The source code is available on <a
-        href="https://github.com/xdanger/xdanger-com"
-        class="border-b">GitHub</a
-      >.
+<footer class="site-footer">
+  <div class="shell">
+    <div class="site-footer__inner">
+      <span>&copy; {siteConfig.author} {year}</span>
+      <a href="https://github.com/xdanger/xdanger-com" rel="noreferrer">
+        <Icon name="mdi:github" aria-hidden="true" focusable="false" /> source on GitHub
+      </a>
     </div>
   </div>
 </footer>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -2,98 +2,35 @@
 import Search from "@/components/Search.astro";
 import ThemeToggle from "@/components/ThemeToggle.astro";
 import { menuLinks } from "@/site.config";
-import { Icon } from "astro-icon/components";
+
+const pathname = Astro.url.pathname.replace(/\/$/, "") || "/";
+const isActive = (path: string) =>
+  path === "/" ? pathname === "/" : pathname === path || pathname.startsWith(`${path}/`);
 ---
 
-<header
-  class="border-grid bg-background/95 supports-[backdrop-filter]:bg-background/60 fixed top-0 z-50 w-full border-b border-dashed border-gray-200 backdrop-blur-sm dark:border-gray-700"
->
-  <div
-    class="relative m-auto flex max-w-4xl items-center border-r border-l border-dashed border-gray-200 p-4 px-4 sm:flex-col sm:px-6 dark:border-gray-700"
-  >
-    <div class="flex w-full justify-between">
-      <nav aria-label="Main menu" id="navigation-menu" class="flex gap-4 sm:gap-6 md:gap-8">
+<header class="site-header">
+  <div class="shell">
+    <div class="site-header__inner">
+      <a href="/" class="wordmark" aria-label="xdanger — home">
+        <span class="mono-x" aria-hidden="true">x</span><span class="label-text">danger</span>
+      </a>
+      <nav class="nav" aria-label="Main">
         {
           menuLinks.map((link) => (
             <a
-              aria-current={Astro.url.pathname === link.path ? "page" : false}
-              class="hover:text-accent"
-              data-astro-prefetch
               href={link.path}
+              aria-current={isActive(link.path) ? "page" : undefined}
+              data-astro-prefetch
             >
-              <Icon name={link.icon} class="inline-block h-5 w-5 align-bottom" />
               {link.title}
             </a>
           ))
         }
       </nav>
-      <div class="flex gap-4">
-        <Search class="" />
+      <div class="header-tools">
+        <Search />
         <ThemeToggle />
-        {
-          /*
-        <mobile-button>
-          <button
-            aria-expanded="false"
-            aria-haspopup="menu"
-            class="group relative ms-4 h-7 w-7 sm:invisible sm:hidden"
-            id="toggle-navigation-menu"
-            type="button"
-          >
-            <span class="sr-only">Open main menu</span>
-            <svg
-              aria-hidden="true"
-              class="absolute start-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 transition-all group-aria-expanded:scale-0 group-aria-expanded:opacity-0"
-              fill="none"
-              focusable="false"
-              id="line-svg"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path d="M3.75 9h16.5m-16.5 6.75h16.5" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="text-accent absolute start-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 scale-0 opacity-0 transition-all group-aria-expanded:scale-100 group-aria-expanded:opacity-100"
-              class="text-accent"
-              fill="none"
-              focusable="false"
-              id="cross-svg"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path d="M6 18L18 6M6 6l12 12" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </button>
-        </mobile-button>
-				*/
-        }
       </div>
     </div>
   </div>
 </header>
-
-<script>
-  import { toggleClass } from "@/utils/domElement";
-
-  class MobileNavBtn extends HTMLElement {
-    #menuOpen: boolean = false;
-
-    connectedCallback() {
-      const headerEl = document.getElementById("main-header")!;
-      const mobileButtonEl = this.querySelector<HTMLButtonElement>("button");
-
-      mobileButtonEl?.addEventListener("click", () => {
-        if (headerEl) toggleClass(headerEl, "menu-open");
-        this.#menuOpen = !this.#menuOpen;
-        mobileButtonEl.setAttribute("aria-expanded", this.#menuOpen.toString());
-      });
-    }
-  }
-
-  customElements.define("mobile-button", MobileNavBtn);
-</script>

--- a/src/components/note/Note.astro
+++ b/src/components/note/Note.astro
@@ -10,39 +10,26 @@ type Props<Tag extends HTMLTag> = Polymorphic<{ as: Tag }> & {
 
 const { as: Tag = "div", note, isPreview = false } = Astro.props;
 const { Content } = await render(note);
+
+const timeOptions: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+};
 ---
 
-<article
-  class:list={[
-    isPreview && "inline-grid rounded-md bg-[rgb(240,240,240)] px-4 py-3 dark:bg-[rgb(33,35,38)]",
-  ]}
-  data-pagefind-body={isPreview ? false : true}
->
-  <Tag class="title" class:list={{ "text-base": isPreview }}>
-    {
-      isPreview ? (
-        <a class="cactus-link" href={`/notes/${note.id}`}>
-          {note.data.title}
-        </a>
-      ) : (
-        <>{note.data.title}</>
-      )
-    }
-  </Tag>
-  <FormattedDate
-    dateTimeOptions={{
-      hour: "2-digit",
-      minute: "2-digit",
-      year: "2-digit",
-      month: "2-digit",
-      day: "2-digit",
-    }}
-    date={note.data.publishDate}
-  />
-  <div
-    class="prose prose-sm prose-cactus mt-4 max-w-none [&>p:last-of-type]:mb-0"
-    class:list={{ "line-clamp-6": isPreview }}
-  >
+<article class="note" data-pagefind-body={isPreview ? false : true}>
+  <FormattedDate class="note__time" date={note.data.publishDate} dateTimeOptions={timeOptions} />
+  {
+    note.data.title && (
+      <Tag class="note__title">
+        {isPreview ? <a href={`/notes/${note.id}`}>{note.data.title}</a> : note.data.title}
+      </Tag>
+    )
+  }
+  <div class="note__body" class:list={{ "note__body--clamp": isPreview }}>
     <Content />
   </div>
 </article>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,6 +1,5 @@
 ---
 import BaseHead from "@/components/BaseHead.astro";
-import SkipLink from "@/components/SkipLink.astro";
 import ThemeProvider from "@/components/ThemeProvider.astro";
 import Footer from "@/components/layout/Footer.astro";
 import Header from "@/components/layout/Header.astro";
@@ -12,7 +11,7 @@ const {
 } = Astro.props;
 ---
 
-<html class="scroll-smooth" lang={siteConfig.lang}>
+<html lang={siteConfig.lang}>
   <head>
     <BaseHead
       articleDate={articleDate}
@@ -22,25 +21,15 @@ const {
       post={post}
     />
   </head>
-  <body class="bg-background overscroll-none antialiased dark:scrollbar-thumb-gray-700">
-    <div
-      class="text-foreground text-offgray dark:text-offgray-300 flex min-h-svh min-w-svw flex-col text-sm"
-    >
-      <ThemeProvider />
-      <SkipLink />
-      <Header />
-      <main id="main" class="border-grid flex flex-grow flex-col pt-24">
-        <slot />
-      </main>
-      <Footer />
-    </div>
-    <!-- Overlay vertical borders for entire page (another approach) -->
-    <div class="pointer-events-none fixed inset-0" style="z-index: 5">
-      <div
-        class="mx-auto h-full max-w-4xl border-r border-l border-dashed border-gray-200 dark:border-gray-700"
-      >
-      </div>
-    </div>
+  <body>
+    <ThemeProvider />
+    <div class="guides" aria-hidden="true"></div>
+    <a href="#main" class="skip-link">Skip to content</a>
+    <Header />
+    <main id="main" class="shell">
+      <slot />
+    </main>
+    <Footer />
     <Analytics />
   </body>
 </html>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,7 +1,6 @@
 ---
 import { render } from "astro:content";
 import Masthead from "@/components/blog/Masthead.astro";
-// import TOC from "@/components/blog/TOC.astro";
 import WebMentions from "@/components/blog/webmentions/index.astro";
 import BaseLayout from "./Base.astro";
 
@@ -9,69 +8,89 @@ const { post } = Astro.props;
 const { ogImage, title, description, updatedDate, publishDate } = post.data;
 const socialImage = ogImage ?? `/og-image/${post.id}.png`;
 const articleDate = updatedDate?.toISOString() ?? publishDate.toISOString();
-// const { headings, remarkPluginFrontmatter } = await render(post);
-const { remarkPluginFrontmatter } = await render(post);
+const { headings, remarkPluginFrontmatter } = await render(post);
 const readingTime: string = remarkPluginFrontmatter.readingTime;
+const toc = headings.filter((h) => h.depth === 2 || h.depth === 3);
 ---
 
 <BaseLayout meta={{ articleDate, description, ogImage: socialImage, title, post }}>
-  <section
-    class="flex flex-col border-b border-dashed border-gray-200 pb-4 sm:pb-6 dark:border-gray-700"
-  >
-    <div id="blog-hero" class="container m-auto max-w-3xl p-4 sm:px-6">
-      <div class="mb-4"><a href="/posts" class="border-b border-solid">← back to blog</a></div>
-      <Masthead content={post} readingTime={readingTime} />
-    </div>
-  </section>
-  <article class="flex-colgrow flex break-words" data-pagefind-body>
-    <div
-      class="container m-auto max-w-3xl flex-col gap-10 p-4 py-4 sm:px-6 sm:py-6 md:py-10 lg:flex-row lg:items-start lg:py-16"
-    >
-      <!-- {!!headings.length && <TOC headings={headings} />} -->
-      <div
-        class="prose prose-headings:font-semibold prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none max-w-3xl"
-      >
-        <slot />
+  <article class="article-wrap">
+    <Masthead content={post} readingTime={readingTime} />
+    <div class="article-layout">
+      <div>
+        <div class="prose" data-pagefind-body>
+          <slot />
+        </div>
         <WebMentions />
       </div>
+      {
+        toc.length > 0 && (
+          <nav class="toc" aria-label="On this page">
+            <p class="toc__label">On this page</p>
+            <ul>
+              {toc.map((h) => (
+                <li>
+                  <a href={`#${h.slug}`} class:list={["toc-link", { "toc-h3": h.depth === 3 }]}>
+                    {h.text}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )
+      }
     </div>
   </article>
-  <button
-    class="hover:border-link fixed end-4 bottom-8 z-90 flex h-10 w-10 translate-y-28 cursor-pointer items-center justify-center rounded-full border-2 border-transparent bg-zinc-200 text-3xl opacity-0 transition-all transition-discrete duration-300 data-[show=true]:translate-y-0 data-[show=true]:opacity-100 sm:end-8 sm:h-12 sm:w-12 dark:bg-zinc-700"
-    data-show="false"
-    id="to-top-btn"
-  >
-    <span class="sr-only">Back to top</span>
-    <svg
-      aria-hidden="true"
-      class="h-6 w-6"
-      fill="none"
-      focusable="false"
-      stroke="currentColor"
-      stroke-width="2"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
+
+  <button class="to-top" id="to-top" data-show="false" type="button" aria-label="Back to top">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
       <path d="M4.5 15.75l7.5-7.5 7.5 7.5" stroke-linecap="round" stroke-linejoin="round"></path>
     </svg>
   </button>
 </BaseLayout>
 
 <script>
-  const scrollBtn = document.getElementById("to-top-btn") as HTMLButtonElement;
-  const targetHeader = document.getElementById("blog-hero") as HTMLDivElement;
-
-  function callback(entries: IntersectionObserverEntry[]) {
-    entries.forEach((entry) => {
-      // only show the scroll to top button when the heading is out of view
-      scrollBtn.dataset.show = (!entry.isIntersecting).toString();
-    });
+  // Back-to-top
+  const btn = document.getElementById("to-top");
+  if (btn) {
+    const onScroll = () => {
+      btn.dataset.show = String(window.scrollY > 600);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    btn.addEventListener("click", () => window.scrollTo({ top: 0, behavior: "smooth" }));
   }
 
-  scrollBtn.addEventListener("click", () => {
-    document.documentElement.scrollTo({ behavior: "smooth", top: 0 });
-  });
+  // TOC scrollspy
+  const links = Array.from(document.querySelectorAll<HTMLAnchorElement>(".toc a"));
+  if (links.length) {
+    const byId = new Map<string, HTMLAnchorElement>();
+    for (const a of links) {
+      const id = decodeURIComponent(a.hash.slice(1));
+      if (id) byId.set(id, a);
+    }
+    const targets = [...byId.keys()]
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => Boolean(el));
 
-  const observer = new IntersectionObserver(callback);
-  observer.observe(targetHeader);
+    let active: HTMLAnchorElement | null = null;
+    const setActive = (id: string) => {
+      const next = byId.get(id) ?? null;
+      if (next === active) return;
+      active?.classList.remove("is-active");
+      next?.classList.add("is-active");
+      active = next;
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]) setActive(visible[0].target.id);
+      },
+      { rootMargin: "-10% 0px -70% 0px", threshold: 0 },
+    );
+    targets.forEach((t) => observer.observe(t));
+  }
 </script>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -61,7 +61,8 @@ const toc = headings.filter((h) => h.depth === 2 || h.depth === 3);
     btn.addEventListener("click", () => window.scrollTo({ top: 0, behavior: "smooth" }));
   }
 
-  // TOC scrollspy
+  // TOC scrollspy — highlight the last heading scrolled past (handles long
+  // sections and the regions before the first / after the last heading)
   const links = Array.from(document.querySelectorAll<HTMLAnchorElement>(".toc a"));
   if (links.length) {
     const byId = new Map<string, HTMLAnchorElement>();
@@ -74,23 +75,25 @@ const toc = headings.filter((h) => h.depth === 2 || h.depth === 3);
       .filter((el): el is HTMLElement => Boolean(el));
 
     let active: HTMLAnchorElement | null = null;
-    const setActive = (id: string) => {
-      const next = byId.get(id) ?? null;
+    const setActive = (next: HTMLAnchorElement | null) => {
       if (next === active) return;
       active?.classList.remove("is-active");
       next?.classList.add("is-active");
       active = next;
     };
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visible = entries
-          .filter((e) => e.isIntersecting)
-          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
-        if (visible[0]) setActive(visible[0].target.id);
-      },
-      { rootMargin: "-10% 0px -70% 0px", threshold: 0 },
-    );
-    targets.forEach((t) => observer.observe(t));
+    const syncToc = () => {
+      const offset = 140; // px from the top that counts as the "current" section
+      let currentId: string | null = null;
+      for (const t of targets) {
+        if (t.getBoundingClientRect().top <= offset) currentId = t.id;
+        else break; // headings are in document order
+      }
+      setActive(currentId ? (byId.get(currentId) ?? null) : null);
+    };
+
+    syncToc();
+    window.addEventListener("scroll", syncToc, { passive: true });
+    window.addEventListener("resize", syncToc, { passive: true });
   }
 </script>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,17 +2,23 @@
 import PageLayout from "@/layouts/Base.astro";
 
 const meta = {
-  description: "Oops! It looks like this page is lost in space!",
-  title: "Oops! You found a missing page!",
+  description: "This page doesn't exist.",
+  title: "404 — Page not found",
 };
 ---
 
 <PageLayout meta={meta}>
-  <section class="flex flex-col pb-4 sm:pb-6">
-    <div class="container m-auto max-w-3xl p-4 sm:px-6">
-      <h1 class="title mb-8">404 &middot; not found</h1>
-      <p class="mb-2 text-base">oops ... something went wrong</p>
-      <p class="text-base">please use the navigation to find your way back</p>
-    </div>
-  </section>
+  <div class="col" style="padding-block: var(--sp-9)">
+    <span class="label">Error</span>
+    <p class="bigcode" aria-hidden="true">404</p>
+    <h1 class="page-head__title" style="margin-top: var(--sp-2)">页面走丢了</h1>
+    <p class="page-head__sub" style="max-width: 34rem; line-height: 1.7">
+      This page doesn't exist — or it did, on one of the platforms this blog has outlived. The
+      writing, at least, is still here.
+    </p>
+    <p style="margin-top: var(--sp-6); display: flex; gap: var(--sp-6); flex-wrap: wrap">
+      <a class="backlink" href="/">← Back home</a>
+      <a class="backlink" href="/posts">Browse all posts →</a>
+    </p>
+  </div>
 </PageLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,18 +1,46 @@
 ---
-import AboutMe from "@/components/AboutMe.astro";
+import SocialList from "@/components/SocialList.astro";
 import PageLayout from "@/layouts/Base.astro";
 
 const meta = {
-  description: "About Yunjie Dai",
+  description: "About Yunjie Dai — father, coder, CEO of TapTap, co-founder of XD Inc.",
   title: "About",
 };
 ---
 
 <PageLayout meta={meta}>
-  <section class="flex flex-col pb-4 sm:pb-6">
-    <div class="container m-auto max-w-3xl p-4 sm:px-6">
-      <h1 class="title mb-6">About</h1>
-      <AboutMe showIntro={false} />
+  <div class="col">
+    <div class="page-head">
+      <span class="label">About</span>
+      <h1 class="page-head__title">About</h1>
+      <p class="page-head__sub">Yunjie Dai · 戴云杰 · @xdanger</p>
     </div>
-  </section>
+
+    <div class="prose" style="padding-bottom: var(--sp-8)">
+      <p>
+        I'm Yunjie Dai — a father first, a coder by habit, and a builder of products by trade. This
+        is where I keep notes on technology, products, investing, and the occasional thought about
+        life.
+      </p>
+
+      <h2>What I'm doing</h2>
+      <p>
+        Presently I'm CEO of <a href="https://www.taptap.com/">TapTap</a> and co-founder of <a
+          href="https://www.xd.com/">XD Inc</a
+        > — we build games and the platforms around them.
+      </p>
+
+      <h2>Before</h2>
+      <p>
+        Earlier I co-founded <a href="https://www.verycd.com/">VeryCD</a>, which taught me more
+        about the internet than any job since. A lot of the older posts here go back that far — this
+        site has outlived several platforms, and the writing has moved along with it.
+      </p>
+
+      <h2>Find me</h2>
+      <p>
+        I'm <span class="handle">xdanger</span> in most places: <SocialList />
+      </p>
+    </div>
+  </div>
 </PageLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,59 +5,64 @@ import PostPreview from "@/components/blog/PostPreview.astro";
 import Note from "@/components/note/Note.astro";
 import { getAllPosts } from "@/data/post";
 import PageLayout from "@/layouts/Base.astro";
+import { siteConfig } from "@/site.config";
 import { collectionDateSort } from "@/utils/date";
 
-// Posts
 const MAX_POSTS = 10;
 const allPosts = await getAllPosts();
 const allPostsByDate = allPosts
   .sort(collectionDateSort)
   .slice(0, MAX_POSTS) as CollectionEntry<"post">[];
 
-// Notes
-const MAX_NOTES = 5;
+const MAX_NOTES = 3;
 const allNotes = await getCollection("note");
 const latestNotes = allNotes.sort(collectionDateSort).slice(0, MAX_NOTES);
 ---
 
 <PageLayout meta={{ title: "Home" }}>
-  <section class="flex flex-col">
-    <div class="container m-auto max-w-3xl p-4 sm:px-6">
+  <div class="col">
+    <section class="identity">
+      <h1 class="identity__name">{siteConfig.author}</h1>
+      <p class="identity__tagline">Notes on tech, products, and life.</p>
       <AboutMe />
-    </div>
-  </section>
-  <section class="flex flex-col border-t border-dashed border-gray-200 py-10 dark:border-gray-700">
-    <div class="container m-auto max-w-3xl px-4 sm:px-6">
-      <h2 class="mb-6"><a href="/posts" class="text-accent">from the blog</a></h2>
-      <ul class="space-y-4" role="list">
+    </section>
+
+    <hr class="rule-x" />
+
+    <section style="padding-top: var(--sp-7)">
+      <div class="section-head">
+        <span class="label">From the blog</span>
+        <span class="section-head__line" aria-hidden="true"></span>
+        <a class="section-head__link" href="/posts">All posts →</a>
+      </div>
+      <ul class="leaders" role="list">
         {
           allPostsByDate.map((p) => (
-            <li class="grid gap-2 sm:grid-cols-[auto_1fr]">
+            <li>
               <PostPreview post={p} />
             </li>
           ))
         }
       </ul>
-    </div>
-  </section>
-  {
-    latestNotes.length > 0 && (
-      <section class="flex flex-col border-t border-dashed border-gray-200 py-10 dark:border-gray-700">
-        <div class="container m-auto max-w-3xl px-4 sm:px-6">
-          <h2 class="mb-6">
-            <a href="/notes" class="text-accent">
-              notes taking
+    </section>
+
+    {
+      latestNotes.length > 0 && (
+        <section style="padding-top: var(--sp-8); padding-bottom: var(--sp-6)">
+          <div class="section-head">
+            <span class="label">Notes</span>
+            <span class="section-head__line" aria-hidden="true" />
+            <a class="section-head__link" href="/notes">
+              All notes →
             </a>
-          </h2>
-          <ul class="space-y-4" role="list">
+          </div>
+          <div class="notes">
             {latestNotes.map((note) => (
-              <li>
-                <Note note={note} as="h3" isPreview />
-              </li>
+              <Note note={note} as="h3" isPreview />
             ))}
-          </ul>
-        </div>
-      </section>
-    )
-  }
+          </div>
+        </section>
+      )
+    }
+  </div>
 </PageLayout>

--- a/src/pages/notes/[...page].astro
+++ b/src/pages/notes/[...page].astro
@@ -18,45 +18,41 @@ export const getStaticPaths = (async ({ paginate }) => {
 const { page } = Astro.props;
 
 const meta = {
-  description: "Read my collection of notes",
+  description: "Short, timestamped thoughts — half-formed on purpose.",
   title: "Notes",
 };
 
 const paginationProps = {
-  ...(page.url.prev && {
-    prevUrl: {
-      text: "← Previous Page",
-      url: page.url.prev,
-    },
-  }),
-  ...(page.url.next && {
-    nextUrl: {
-      text: "Next Page →",
-      url: page.url.next,
-    },
-  }),
+  ...(page.url.prev && { prevUrl: { text: "Newer", url: page.url.prev } }),
+  ...(page.url.next && { nextUrl: { text: "Older", url: page.url.next } }),
 };
 ---
 
 <PageLayout meta={meta}>
-  <section class="flex flex-col pb-4 sm:pb-6">
-    <div class="container m-auto max-w-3xl p-4 sm:px-6">
-      <h1 class="title mb-6 flex items-center gap-3">
-        Notes <a class="text-accent" href="/notes/rss.xml" target="_blank">
-          <span class="sr-only">RSS feed</span>
-          <Icon aria-hidden="true" class="h-6 w-6" focusable="false" name="mdi:rss" />
+  <div class="col">
+    <div class="page-head">
+      <div class="section-head" style="margin-bottom: 0">
+        <span class="label">Notes</span>
+        <span class="section-head__line" aria-hidden="true"></span>
+        <a class="rss" href="/notes/rss.xml" target="_blank">
+          <Icon name="mdi:rss" aria-hidden="true" focusable="false" /> RSS
         </a>
-      </h1>
-      <ul class="mt-6 space-y-8 text-start">
-        {
-          page.data.map((note) => (
-            <li class="">
-              <Note note={note} as="h2" isPreview />
-            </li>
-          ))
-        }
-      </ul>
-      <Pagination {...paginationProps} />
+      </div>
+      <h1 class="page-head__title">Notes</h1>
+      <p class="page-head__sub">Short, timestamped thoughts — half-formed on purpose.</p>
     </div>
-  </section>
+
+    {
+      page.data.length > 0 ? (
+        <div class="notes">
+          {page.data.map((note) => (
+            <Note note={note} as="h2" isPreview />
+          ))}
+        </div>
+      ) : (
+        <p class="meta">No notes yet.</p>
+      )
+    }
+    <Pagination {...paginationProps} />
+  </div>
 </PageLayout>

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -1,11 +1,9 @@
 ---
 import { getCollection } from "astro:content";
-
 import Note from "@/components/note/Note.astro";
 import PageLayout from "@/layouts/Base.astro";
 import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
 
-// if you're using an adaptor in SSR mode, getStaticPaths wont work -> https://docs.astro.build/en/guides/routing/#modifying-the-slug-example-for-ssr
 export const getStaticPaths = (async () => {
   const allNotes = await getCollection("note");
   return allNotes.map((note) => ({
@@ -27,9 +25,10 @@ const meta = {
 ---
 
 <PageLayout meta={meta}>
-  <section class="flex flex-col pb-4 sm:pb-6">
-    <div class="container m-auto max-w-3xl p-4 sm:px-6">
+  <div class="col" style="padding-block: var(--sp-7) var(--sp-8)">
+    <a href="/notes" class="backlink" style="margin-bottom: var(--sp-5)">← All notes</a>
+    <div class="note-card">
       <Note as="h1" note={note} />
     </div>
-  </section>
+  </div>
 </PageLayout>

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -77,7 +77,7 @@ const descYearKeys = Object.keys(groupedByYear).sort((a, b) => +b - +a);
         <div class="taglist">
           {
             allTagsWithCount.map(([tag, count]) => (
-              <a class="tag" href={`/tags/${tag}`}>
+              <a class="tag" href={`/tags/${encodeURIComponent(tag)}`}>
                 <span class="hash" aria-hidden="true">
                   #
                 </span>

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -1,30 +1,27 @@
 ---
 import Pagination from "@/components/Paginator.astro";
 import PostPreview from "@/components/blog/PostPreview.astro";
-import { getAllPosts, getUniqueTags, groupPostsByYear } from "@/data/post";
+import { getAllPosts, getUniqueTagsWithCount, groupPostsByYear } from "@/data/post";
 import PageLayout from "@/layouts/Base.astro";
 import { collectionDateSort } from "@/utils/date";
-// import type { GetStaticPaths, Page } from "astro";
 import type { GetStaticPaths } from "astro";
 import { Icon } from "astro-icon/components";
 
 export const getStaticPaths = (async ({ paginate }) => {
   const MAX_POSTS_PER_PAGE = 40;
-  const MAX_TAGS = 20;
+  const MAX_TAGS = 16;
   const allPosts = await getAllPosts();
-  const uniqueTags = getUniqueTags(allPosts).slice(0, MAX_TAGS);
-  return paginate(allPosts.sort(collectionDateSort), {
+  const sorted = allPosts.sort(collectionDateSort);
+  const allTagsWithCount = getUniqueTagsWithCount(allPosts).slice(0, MAX_TAGS);
+  const totalPosts = allPosts.length;
+  const earliestYear = sorted.at(-1)?.data.publishDate.getFullYear() ?? new Date().getFullYear();
+  return paginate(sorted, {
     pageSize: MAX_POSTS_PER_PAGE,
-    props: { uniqueTags },
+    props: { allTagsWithCount, totalPosts, earliestYear },
   });
 }) satisfies GetStaticPaths;
 
-// interface Props {
-//   page: Page<CollectionEntry<"post">>;
-//   uniqueTags: string[];
-// }
-
-const { page, uniqueTags } = Astro.props;
+const { page, allTagsWithCount, totalPosts, earliestYear } = Astro.props;
 
 const meta = {
   description: "Read my collection of posts and the things that interest me",
@@ -32,18 +29,8 @@ const meta = {
 };
 
 const paginationProps = {
-  ...(page.url.prev && {
-    prevUrl: {
-      text: "← Previous Page",
-      url: page.url.prev,
-    },
-  }),
-  ...(page.url.next && {
-    nextUrl: {
-      text: "Next Page →",
-      url: page.url.next,
-    },
-  }),
+  ...(page.url.prev && { prevUrl: { text: "Newer", url: page.url.prev } }),
+  ...(page.url.next && { nextUrl: { text: "Older", url: page.url.next } }),
 };
 
 const groupedByYear = groupPostsByYear(page.data);
@@ -51,79 +38,69 @@ const descYearKeys = Object.keys(groupedByYear).sort((a, b) => +b - +a);
 ---
 
 <PageLayout meta={meta}>
-  <section class="flex flex-col pb-4 sm:pb-6">
-    <div class="container m-auto max-w-3xl p-4 sm:px-6">
-      <div class="mb-6 flex items-center gap-3">
-        <h1 class="title">Posts</h1>
-        <a class="text-accent" href="/rss.xml" target="_blank">
-          <span class="sr-only">RSS feed</span>
-          <Icon aria-hidden="true" class="h-6 w-6" focusable="false" name="mdi:rss" />
-        </a>
-      </div>
-      <div class="grid sm:grid-cols-[3fr_1fr] sm:gap-x-8 sm:gap-y-16">
-        <div>
+  <div class="page-head">
+    <span class="label">Posts</span>
+    <h1 class="page-head__title">All posts</h1>
+    <p class="page-head__sub">{totalPosts} posts since {earliestYear} · mostly in Chinese</p>
+  </div>
+
+  <div class="index-layout">
+    <div>
+      {
+        descYearKeys.map((yearKey) => (
+          <section class="year-group" aria-labelledby={`year-${yearKey}`}>
+            <div class="year-group__head">
+              <span class="year-group__year" id={`year-${yearKey}`}>
+                {yearKey}
+              </span>
+              <span class="year-group__count">{groupedByYear[yearKey]?.length} posts</span>
+            </div>
+            <ul class="leaders" role="list">
+              {groupedByYear[yearKey]?.map((p) => (
+                <li>
+                  <PostPreview post={p} compactDate />
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))
+      }
+      <Pagination {...paginationProps} />
+    </div>
+
+    <aside class="index-side stack-6">
+      <div>
+        <div class="section-head">
+          <span class="label">Tags</span>
+          <span class="section-head__line" aria-hidden="true"></span>
+        </div>
+        <div class="taglist">
           {
-            descYearKeys.map((yearKey) => (
-              <section aria-labelledby={`year-${yearKey}`}>
-                <h2 id={`year-${yearKey}`} class="title text-lg">
-                  <span class="sr-only">Posts in</span>
-                  {yearKey}
-                </h2>
-                <ul class="mt-5 mb-16 space-y-4 text-start">
-                  {groupedByYear[yearKey]?.map((p) => (
-                    <li class="grid gap-2 sm:grid-cols-[auto_1fr] sm:[&_q]:col-start-2">
-                      <PostPreview post={p} />
-                    </li>
-                  ))}
-                </ul>
-              </section>
+            allTagsWithCount.map(([tag, count]) => (
+              <a class="tag" href={`/tags/${tag}`}>
+                <span class="hash" aria-hidden="true">
+                  #
+                </span>
+                {tag}
+                <span class="ct">{count}</span>
+              </a>
             ))
           }
-          <Pagination {...paginationProps} />
         </div>
-        {
-          !!uniqueTags.length && (
-            <aside>
-              <h2 class="title mb-4 flex items-center gap-2 text-lg">
-                Tags
-                <svg
-                  aria-hidden="true"
-                  class="h-6 w-6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path d="M0 0h24v24H0z" fill="none" stroke="none" />
-                  <path d="M7.859 6h-2.834a2.025 2.025 0 0 0 -2.025 2.025v2.834c0 .537 .213 1.052 .593 1.432l6.116 6.116a2.025 2.025 0 0 0 2.864 0l2.834 -2.834a2.025 2.025 0 0 0 0 -2.864l-6.117 -6.116a2.025 2.025 0 0 0 -1.431 -.593z" />
-                  <path d="M17.573 18.407l2.834 -2.834a2.025 2.025 0 0 0 0 -2.864l-7.117 -7.116" />
-                  <path d="M6 9h-.01" />
-                </svg>
-              </h2>
-              <ul class="flex flex-wrap gap-2">
-                {uniqueTags.map((tag) => (
-                  <li>
-                    <a class="cactus-link flex items-center justify-center" href={`/tags/${tag}`}>
-                      <span aria-hidden="true">#</span>
-                      <span class="sr-only">View all posts with the tag</span>
-                      {tag}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-              <span class="mt-4 block sm:text-end">
-                <a class="hover:text-link" href="/tags">
-                  View all <span aria-hidden="true">→</span>
-                  <span class="sr-only">blog tags</span>
-                </a>
-              </span>
-            </aside>
-          )
-        }
+        <p style="margin-top: var(--sp-4)">
+          <a class="section-head__link" href="/tags">View all tags →</a>
+        </p>
       </div>
-    </div>
-  </section>
+
+      <div>
+        <div class="section-head">
+          <span class="label">Subscribe</span>
+          <span class="section-head__line" aria-hidden="true"></span>
+        </div>
+        <a class="rss" href="/rss.xml" target="_blank">
+          <Icon name="mdi:rss" aria-hidden="true" focusable="false" /> RSS feed
+        </a>
+      </div>
+    </aside>
+  </div>
 </PageLayout>

--- a/src/pages/tags/[tag]/[...page].astro
+++ b/src/pages/tags/[tag]/[...page].astro
@@ -15,7 +15,7 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
   return uniqueTags.flatMap((tag) => {
     const filterPosts = sortedPosts.filter((post) => post.data.tags.includes(tag));
     return paginate(filterPosts, {
-      pageSize: 10,
+      pageSize: 30,
       params: { tag },
     });
   });
@@ -34,42 +34,34 @@ const meta = {
 };
 
 const paginationProps = {
-  ...(page.url.prev && {
-    prevUrl: {
-      text: "← Previous Tags",
-      url: page.url.prev,
-    },
-  }),
-  ...(page.url.next && {
-    nextUrl: {
-      text: "Next Tags →",
-      url: page.url.next,
-    },
-  }),
+  ...(page.url.prev && { prevUrl: { text: "Newer", url: page.url.prev } }),
+  ...(page.url.next && { nextUrl: { text: "Older", url: page.url.next } }),
 };
 ---
 
 <PageLayout meta={meta}>
-  <section class="flex flex-col pb-4 sm:pb-6">
-    <div class="container m-auto max-w-3xl p-4 sm:px-6">
-      <h1 class="sr-only">Posts with the tag {tag}</h1>
-      <a class="title text-accent" href="/tags"><span class="sr-only">All {" "}</span>Tags</a>
-      <span aria-hidden="true" class="ms-2 me-3 text-xl">→</span>
-      <span aria-hidden="true" class="text-xl">#{tag}</span>
-
-      <section aria-labelledby={`tags-${tag}`}>
-        <h2 id={`tags-${tag}`} class="sr-only">Post List</h2>
-        <ul class="mt-6 space-y-4">
-          {
-            page.data.map((p) => (
-              <li class="grid gap-2 sm:grid-cols-[auto_1fr]">
-                <PostPreview as="h2" post={p} />
-              </li>
-            ))
-          }
-        </ul>
-        <Pagination {...paginationProps} />
-      </section>
+  <div class="col">
+    <div class="page-head">
+      <nav class="crumbs" aria-label="Breadcrumb">
+        <a href="/posts">Posts</a><span class="sep" aria-hidden="true">/</span><a href="/tags"
+          >Tags</a
+        ><span class="sep" aria-hidden="true">/</span><span>{tag}</span>
+      </nav>
+      <h1 class="page-head__title"><span style="color: var(--accent)">#</span>{tag}</h1>
+      <p class="page-head__sub">
+        {page.total} post{page.total === 1 ? "" : "s"} tagged “{tag}”
+      </p>
     </div>
-  </section>
+
+    <ul class="leaders" role="list">
+      {
+        page.data.map((p) => (
+          <li>
+            <PostPreview post={p} />
+          </li>
+        ))
+      }
+    </ul>
+    <Pagination {...paginationProps} />
+  </div>
 </PageLayout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -22,7 +22,11 @@ const meta = {
     <div class="taglist" style="padding-bottom: var(--sp-8)">
       {
         allTags.map(([tag, count]) => (
-          <a class="tag" href={`/tags/${tag}`} title={`View posts with the tag: ${tag}`}>
+          <a
+            class="tag"
+            href={`/tags/${encodeURIComponent(tag)}`}
+            title={`View posts with the tag: ${tag}`}
+          >
             <span class="hash" aria-hidden="true">
               #
             </span>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -12,28 +12,25 @@ const meta = {
 ---
 
 <PageLayout meta={meta}>
-  <section class="flex flex-col pb-4 sm:pb-6">
-    <div class="container m-auto max-w-3xl p-4 sm:px-6">
-      <h1 class="title mb-6">Tags</h1>
-      <ul class="space-y-3">
-        {
-          allTags.map(([tag, val]) => (
-            <li class="flex items-center gap-x-2">
-              <a
-                class="cactus-link inline-block"
-                data-astro-prefetch
-                href={`/tags/${tag}`}
-                title={`View posts with the tag: ${tag}`}
-              >
-                &#35;{tag}
-              </a>
-              <span class="inline-block">
-                - {val} Post{val > 1 && "s"}
-              </span>
-            </li>
-          ))
-        }
-      </ul>
+  <div class="col">
+    <div class="page-head">
+      <span class="label">Tags</span>
+      <h1 class="page-head__title">All tags</h1>
+      <p class="page-head__sub">{allTags.length} topics across the archive</p>
     </div>
-  </section>
+
+    <div class="taglist" style="padding-bottom: var(--sp-8)">
+      {
+        allTags.map(([tag, count]) => (
+          <a class="tag" href={`/tags/${tag}`} title={`View posts with the tag: ${tag}`}>
+            <span class="hash" aria-hidden="true">
+              #
+            </span>
+            {tag}
+            <span class="ct">{count}</span>
+          </a>
+        ))
+      }
+    </div>
+  </div>
 </PageLayout>

--- a/src/styles/blocks/search.css
+++ b/src/styles/blocks/search.css
@@ -1,40 +1,107 @@
 @import "@pagefind/default-ui/css/ui.css";
 
 :root {
-  --pagefind-ui-font: inherit;
+  --pagefind-ui-font: var(--font-body);
 }
 
-#cactus__search {
-  --pagefind-ui-primary: var(--color-accent);
-  --pagefind-ui-text: var(--color-global-text);
-  --pagefind-ui-background: var(--color-zinc-100);
-  --pagefind-ui-border: var(--color-zinc-300);
-  --pagefind-ui-border-width: 1px;
+/* search button icon sizing */
+.search-btn svg {
+  width: 14px;
+  height: 14px;
+  flex: none;
+}
 
-  [data-theme="dark"] & {
-    --pagefind-ui-background: var(--color-zinc-800);
-    --pagefind-ui-border: var(--color-zinc-500);
+/* ---- dialog shell ---- */
+.search-dialog {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  max-width: 38rem;
+  max-height: calc(100% - 8rem);
+  border: var(--hair) solid var(--rule-strong);
+  border-radius: var(--radius);
+  background: var(--paper);
+  color: var(--ink);
+  box-shadow: 0 18px 50px -24px rgba(0, 0, 0, 0.45);
+}
+.search-dialog:not([open]) {
+  display: none;
+}
+.search-dialog[open] {
+  display: flex;
+}
+.search-dialog::backdrop {
+  background: color-mix(in oklab, var(--paper-sunk) 70%, transparent);
+  backdrop-filter: blur(2px);
+}
+@media (min-width: 640px) {
+  .search-dialog {
+    margin: 12vh auto auto;
   }
+}
+.search-dialog .dialog-frame {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  width: 100%;
+  padding: var(--sp-4);
+}
+.search-close {
+  align-self: flex-end;
+  font-family: var(--font-mono);
+  font-size: var(--fs-micro);
+  letter-spacing: var(--track-meta);
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  border: var(--hair) solid var(--rule-strong);
+  border-radius: 2px;
+  padding: 0.2em 0.5em;
+  background: transparent;
+  cursor: pointer;
+}
+.search-close:hover {
+  color: var(--ink);
+  border-color: var(--ink-faint);
+}
+.search-dev-note {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--ink-faint);
+  text-align: center;
+  padding: var(--sp-4) var(--sp-2) var(--sp-6);
+}
+
+/* ---- Pagefind UI theming ---- */
+#cactus__search {
+  --pagefind-ui-primary: var(--accent);
+  --pagefind-ui-text: var(--ink);
+  --pagefind-ui-background: var(--paper);
+  --pagefind-ui-border: var(--rule-strong);
+  --pagefind-ui-tag: var(--paper-raised);
+  --pagefind-ui-border-width: 1px;
+  --pagefind-ui-border-radius: var(--radius);
+}
+
+#cactus__search .pagefind-ui__search-input {
+  font-family: var(--font-mono);
+  background: var(--paper-raised);
 }
 
 #cactus__search .pagefind-ui__search-clear {
-  width: calc(60px * var(--pagefind-ui-scale));
   padding: 0;
   background-color: transparent;
   overflow: hidden;
 }
-
 #cactus__search .pagefind-ui__search-clear:focus {
-  outline: 1px solid var(--color-accent-2);
+  outline: 1px solid var(--accent);
 }
-
 #cactus__search .pagefind-ui__search-clear::before {
   content: "";
   -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' %3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'%3E%3C/path%3E%3C/svg%3E")
-    center / 60% no-repeat;
+    center / 55% no-repeat;
   mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' %3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'%3E%3C/path%3E%3C/svg%3E")
-    center / 60% no-repeat;
-  background-color: var(--color-accent);
+    center / 55% no-repeat;
+  background-color: var(--accent);
   display: block;
   width: 100%;
   height: 100%;
@@ -42,32 +109,25 @@
 
 #cactus__search .pagefind-ui__result {
   border: 0;
+  border-top: var(--hair) dotted var(--rule);
 }
-
+#cactus__search .pagefind-ui__result-title {
+  font-family: var(--font-body);
+}
 #cactus__search .pagefind-ui__result-link {
-  background-size: 100% 6px;
-  background-position: bottom;
-  background-repeat: repeat-x;
-  background-image: linear-gradient(
-    transparent,
-    transparent 5px,
-    var(--color-global-text) 5px,
-    var(--color-global-text)
-  );
-}
-
-#cactus__search .pagefind-ui__result-link:hover {
+  color: var(--ink);
   text-decoration: none;
-  background-image: linear-gradient(
-    transparent,
-    transparent 4px,
-    var(--color-link) 4px,
-    var(--color-link)
-  );
 }
-
+#cactus__search .pagefind-ui__result-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+#cactus__search .pagefind-ui__result-excerpt {
+  color: var(--ink-muted);
+}
 #cactus__search mark {
-  color: var(--color-quote);
+  color: var(--accent);
   background-color: transparent;
   font-weight: 600;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -211,7 +211,8 @@ hr {
 /* ============================================================
    FRAME + GUIDE LINES
    ============================================================ */
-/* continuous dotted verticals spanning the full viewport height */
+/* continuous dotted verticals spanning the full viewport height, drawn above
+   the solid content plate so the vertical frame stays visible */
 .guides {
   position: fixed;
   inset: 0;
@@ -219,7 +220,7 @@ hr {
   max-width: var(--shell);
   width: 100%;
   pointer-events: none;
-  z-index: 0;
+  z-index: 2;
 }
 .guides::before,
 .guides::after {
@@ -237,14 +238,15 @@ hr {
   right: var(--pad-x);
 }
 
-/* content plate; transparent so the fixed dotted guides + faint graph-paper
-   grid read through behind the (higher z-index) text */
+/* solid paper plate so the graph-paper grid only shows in the outer margins;
+   the fixed dotted guides (higher z-index) frame its content-column edges */
 .shell {
   position: relative;
   z-index: 1;
   max-width: var(--shell);
   margin-inline: auto;
   padding-inline: var(--pad-x);
+  background: var(--paper);
 }
 @media (max-width: 720px) {
   .guides::before {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,229 +1,1419 @@
-/* would like to ignore ./src/pages/og-image/[slug].png.ts */
+/* ============================================================
+   xdanger.com — design system
+   Editorial, near-monochrome, one amber accent.
+   Display: Newsreader (Latin) + LXGW WenKai Lite (CJK)
+   Body:    Geist (Latin) + system CJK sans
+   Chrome:  iA Writer Mono (mono)
+   ============================================================ */
 @import "tailwindcss";
-/* config for tailwindcss-typography plugin */
+/* @tailwindcss/typography plugin — its low-specificity (:where) prose rules
+   are intentionally overridden by the .prose rules defined below. */
 @config "../../tailwind.config.ts";
 
-/* use a selector-based strategy for dark mode */
+/* selector-based dark mode, kept for any remaining `dark:` utilities */
 @variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
-/* Shadcn UI theme https://ui.shadcn.com/themes */
+/* ============================================================
+   TOKENS
+   ============================================================ */
 :root {
-  --radius: 0.5rem;
-  --background: oklch(98.48% 0 0);
-  --foreground: oklch(0.141 0.005 285.823); /* oklch(26.99% 0.0096 235.05) */
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.623 0.214 259.815);
-  --primary-foreground: oklch(0.97 0.014 254.604);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.623 0.214 259.815);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.623 0.214 259.815);
-  --sidebar-primary-foreground: oklch(0.97 0.014 254.604);
-  --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-  --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.623 0.214 259.815);
+  /* fonts — map onto Astro-registered families (see BaseHead.astro) */
+  --font-serif: var(--font-newsreader), "LXGW WenKai Lite", "Noto Serif SC", Georgia, serif;
+  --font-mono: var(--font-ia-writer-mono), "IBM Plex Mono", ui-monospace, "SFMono-Regular", Menlo,
+    monospace;
+  --font-sans: var(--font-geist), system-ui, -apple-system, "Helvetica Neue", sans-serif;
+  /* BODY / PROSE — Geist for Latin, system CJK sans for Chinese */
+  --font-body: var(--font-geist), system-ui, -apple-system, "PingFang SC", "Microsoft YaHei",
+    "Noto Sans SC", sans-serif;
+  --font-cjk: system-ui, -apple-system, "PingFang SC", "Microsoft YaHei", "Noto Sans SC",
+    sans-serif;
+  /* CJK DISPLAY — brushy serif for titles & section headlines */
+  --font-cjk-display: "LXGW WenKai Lite", "LXGW WenKai", "Noto Serif SC", serif;
+
+  /* type scale */
+  --fs-display: clamp(2.6rem, 1.6rem + 3.6vw, 3.5rem);
+  --fs-h1: clamp(2rem, 1.4rem + 2.2vw, 2.6rem);
+  --fs-h2: 1.55rem;
+  --fs-h3: 1.2rem;
+  --fs-body: 1.1875rem; /* 19px reading */
+  --fs-base: 1rem;
+  --fs-sm: 0.9375rem;
+  --fs-meta: 0.78rem; /* mono labels */
+  --fs-micro: 0.68rem;
+
+  --lh-body: 1.78;
+  --lh-cjk: 1.95;
+  --lh-tight: 1.14;
+  --lh-snug: 1.35;
+
+  --track-meta: 0.12em; /* mono label tracking */
+  --track-wide: 0.2em;
+
+  /* spacing (4px base) */
+  --sp-1: 0.25rem;
+  --sp-2: 0.5rem;
+  --sp-3: 0.75rem;
+  --sp-4: 1rem;
+  --sp-5: 1.5rem;
+  --sp-6: 2rem;
+  --sp-7: 3rem;
+  --sp-8: 4rem;
+  --sp-9: 6rem;
+  --sp-10: 8rem;
+
+  /* layout */
+  --shell: 1140px; /* outer frame where guide lines sit */
+  --col: 46rem; /* primary content column */
+  --measure: 40rem; /* prose measure */
+  --pad-x: clamp(1.25rem, 5vw, 3.5rem);
+
+  --radius: 3px; /* restrained, almost square */
+  --hair: 1px;
 }
 
-.dark {
-  --background: oklch(0.141 0.005 285.823);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 285.885);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.546 0.245 262.881);
-  --primary-foreground: oklch(0.379 0.146 265.522);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.488 0.243 264.376);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.21 0.006 285.885);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.546 0.245 262.881);
-  --sidebar-primary-foreground: oklch(0.379 0.146 265.522);
-  --sidebar-accent: oklch(0.274 0.006 286.033);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.488 0.243 264.376);
+/* ---- LIGHT (warm paper) ---- */
+:root,
+:root[data-theme="light"] {
+  color-scheme: light;
+  --paper: #faf7f0;
+  --paper-raised: #f3eee2;
+  --paper-sunk: #efe9da;
+  --ink: #211e17;
+  --ink-muted: #5c574b;
+  --ink-faint: #938c7c;
+  --rule: #e6dfce;
+  --rule-strong: #d6cdb6;
+  --accent: #9a5a16;
+  --accent-hover: #7c4710;
+  --accent-soft: rgba(154, 90, 22, 0.12);
+  --graph: rgba(120, 104, 70, 0.06);
+  --code-bg: #f1ebdc;
+  --selection: rgba(154, 90, 22, 0.18);
 }
 
-/* you could refactor below to use light-dark(), depending on your target audience */
+/* ---- DARK (true warm charcoal — never navy) ---- */
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --paper: #1b1814;
+  --paper-raised: #232019;
+  --paper-sunk: #161310;
+  --ink: #ece5d6;
+  --ink-muted: #aaa18d;
+  --ink-faint: #6f6856;
+  --rule: #322d24;
+  --rule-strong: #433d31;
+  --accent: #dba04c;
+  --accent-hover: #eab366;
+  --accent-soft: rgba(219, 160, 76, 0.16);
+  --graph: rgba(225, 210, 170, 0.05);
+  --code-bg: #221f18;
+  --selection: rgba(219, 160, 76, 0.22);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+    --paper: #1b1814;
+    --paper-raised: #232019;
+    --paper-sunk: #161310;
+    --ink: #ece5d6;
+    --ink-muted: #aaa18d;
+    --ink-faint: #6f6856;
+    --rule: #322d24;
+    --rule-strong: #433d31;
+    --accent: #dba04c;
+    --accent-hover: #eab366;
+    --accent-soft: rgba(219, 160, 76, 0.16);
+    --graph: rgba(225, 210, 170, 0.05);
+    --code-bg: #221f18;
+    --selection: rgba(219, 160, 76, 0.22);
+  }
+}
+
+/* Tailwind colour aliases so legacy utilities (webmentions, etc.) keep working */
 @theme {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-link: oklch(55.44% 0.0431 185.69);
-  --color-accent: oklch(55.27% 0.195 19.06);
-  --color-accent-2: oklch(18.15% 0 0);
-  --color-quote: oklch(55.27% 0.195 19.06);
-  /* --color-quote: var(--muted-foreground); */
-  --font-sans: "Geist", ui-sans-serif, system-ui, sans-serif;
-  /* Astro registers webfonts under hashed family names exposed via the --font-*
-     variables; reference those (not literal names) so the self-hosted fonts are
-     used, never a locally-installed copy. The variables' trailing generic is a
-     latin-only system font, so CJK glyphs continue past it to LXGW WenKai Lite. */
-  /* Global default: iA Writer Mono (Latin) → LXGW WenKai Lite (CJK) → mono. */
-  --font-mono: var(--font-ia-writer-mono), "LXGW WenKai Lite", ui-monospace, monospace;
-  /* Prose: Newsreader (Latin) → LXGW WenKai Lite (CJK) → global mono stack. */
-  --font-serif: var(--font-newsreader), "LXGW WenKai Lite", var(--font-ia-writer-mono),
-    ui-monospace, monospace;
+  --color-paper: var(--paper);
+  --color-ink: var(--ink);
+  --color-accent: var(--accent);
+  --color-accent-2: var(--ink);
+  --color-background: var(--paper);
+  --color-foreground: var(--ink);
+  --color-global-bg: var(--paper);
+  --color-global-text: var(--ink);
+  --color-link: var(--accent);
+  --color-quote: var(--accent);
 }
 
-@layer base {
-  html {
-    color-scheme: light dark;
-    accent-color: var(--color-accent);
+/* ============================================================
+   BASE
+   ============================================================ */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
 
-    &[data-theme="light"] {
-      color-scheme: light;
-    }
+html {
+  -webkit-text-size-adjust: 100%;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  scroll-behavior: smooth;
+}
 
-    &[data-theme="dark"] {
-      color-scheme: dark;
-      --color-background: oklch(23.64% 0.0045 248);
-      --color-foreground: oklch(83.54% 0 264);
-      --color-primary: oklch(0.546 0.245 262.881);
-      --color-primary-foreground: oklch(0.379 0.146 265.522);
-      --color-link: oklch(70.44% 0.1133 349);
-      --color-accent: oklch(70.91% 0.1415 163.7);
-      --color-accent-2: oklch(94.66% 0 0);
-      --color-quote: oklch(94.8% 0.106 136.49);
-    }
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: var(--paper);
+  /* faint graph-paper texture — shows through in the margins */
+  background-image:
+    repeating-linear-gradient(to right, var(--graph) 0 1px, transparent 1px 26px),
+    repeating-linear-gradient(to bottom, var(--graph) 0 1px, transparent 1px 26px);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: var(--fs-body);
+  line-height: var(--lh-body);
+  font-feature-settings: "kern" 1, "liga" 1;
+}
+
+::selection {
+  background: var(--selection);
+}
+
+:lang(zh) {
+  font-family: var(--font-cjk);
+  line-height: var(--lh-cjk);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--accent-hover);
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+hr {
+  border: 0;
+  border-top: var(--hair) solid var(--rule);
+  margin: var(--sp-7) 0;
+}
+
+/* ============================================================
+   FRAME + GUIDE LINES
+   ============================================================ */
+/* continuous dotted verticals spanning the full viewport height */
+.guides {
+  position: fixed;
+  inset: 0;
+  margin-inline: auto;
+  max-width: var(--shell);
+  width: 100%;
+  pointer-events: none;
+  z-index: 0;
+}
+.guides::before,
+.guides::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  border-left: var(--hair) dotted var(--rule-strong);
+}
+.guides::before {
+  left: var(--pad-x);
+}
+.guides::after {
+  right: var(--pad-x);
+}
+
+/* content plate; transparent so the fixed dotted guides + faint graph-paper
+   grid read through behind the (higher z-index) text */
+.shell {
+  position: relative;
+  z-index: 1;
+  max-width: var(--shell);
+  margin-inline: auto;
+  padding-inline: var(--pad-x);
+}
+@media (max-width: 720px) {
+  .guides::before {
+    left: calc(var(--pad-x) - 2px);
   }
-  body {
-    @apply font-mono;
+  .guides::after {
+    right: calc(var(--pad-x) - 2px);
   }
+}
+
+/* a centered, narrower reading column inside the shell */
+.col {
+  max-width: var(--col);
+  margin-inline: auto;
+}
+.col--wide {
+  max-width: 52rem;
+}
+
+/* horizontal hairline that meets the guide lines */
+.rule-x {
+  border: 0;
+  border-top: var(--hair) dotted var(--rule-strong);
+  margin: 0;
+}
+
+/* ============================================================
+   HEADER
+   ============================================================ */
+.site-header {
+  position: relative;
+  z-index: 1;
+}
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-5);
+  height: 64px;
+  border-bottom: var(--hair) dotted var(--rule-strong);
+}
+.wordmark {
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+}
+.wordmark .mono-x {
+  display: inline-grid;
+  place-items: center;
+  width: 1.45em;
+  height: 1.45em;
+  border: var(--hair) solid var(--ink);
+  color: var(--ink);
+  font-weight: 700;
+}
+.wordmark:hover {
+  color: var(--ink);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-5);
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: var(--track-meta);
+  text-transform: uppercase;
+}
+.nav a {
+  color: var(--ink-muted);
+  padding: 0.5em 0;
+  position: relative;
+}
+.nav a:hover {
+  color: var(--ink);
+}
+.nav a[aria-current="page"] {
+  color: var(--accent);
+}
+.nav a[aria-current="page"]::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 1px;
+  background: var(--accent);
+}
+.header-tools {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+/* search affordance */
+.search-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6em;
+  height: 32px;
+  padding: 0 0.7em;
+  background: transparent;
+  border: var(--hair) solid var(--rule-strong);
+  border-radius: var(--radius);
+  color: var(--ink-faint);
+  font-family: var(--font-mono);
+  font-size: var(--fs-micro);
+  letter-spacing: var(--track-meta);
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.search-btn:hover {
+  border-color: var(--ink-faint);
+  color: var(--ink-muted);
+}
+.search-btn kbd {
+  font-family: var(--font-mono);
+  border: var(--hair) solid var(--rule-strong);
+  border-radius: 2px;
+  padding: 0.1em 0.35em;
+  font-size: 0.92em;
+}
+
+/* icon button (theme toggle, etc.) */
+.icon-btn {
+  display: inline-grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: var(--hair) solid transparent;
+  border-radius: var(--radius);
+  color: var(--ink-muted);
+  cursor: pointer;
+}
+.icon-btn:hover {
+  color: var(--ink);
+  border-color: var(--rule-strong);
+}
+.icon-btn svg {
+  width: 17px;
+  height: 17px;
+}
+.theme-toggle .moon {
+  display: none;
+}
+:root[data-theme="dark"] .theme-toggle .sun {
+  display: none;
+}
+:root[data-theme="dark"] .theme-toggle .moon {
+  display: block;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .theme-toggle .sun {
+    display: none;
+  }
+  :root:not([data-theme="light"]) .theme-toggle .moon {
+    display: block;
+  }
+}
+
+/* ============================================================
+   LABELS / META (mono)
+   ============================================================ */
+.label {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: var(--track-meta);
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 400;
+}
+.label--muted {
+  color: var(--ink-faint);
+}
+.meta {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--ink-faint);
+  letter-spacing: 0.01em;
+}
+.meta--upper {
+  text-transform: uppercase;
+  letter-spacing: var(--track-meta);
+  font-size: var(--fs-meta);
+}
+
+/* breadcrumb */
+.crumbs {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: var(--track-meta);
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.crumbs a {
+  color: var(--ink-muted);
+}
+.crumbs a:hover {
+  color: var(--accent);
+}
+.crumbs .sep {
+  color: var(--rule-strong);
+  margin: 0 0.4em;
+}
+
+/* back link */
+.backlink {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: var(--track-meta);
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+}
+.backlink:hover {
+  color: var(--accent);
+}
+
+/* ============================================================
+   SECTION HEADER
+   ============================================================ */
+.section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-5);
+}
+.section-head .label {
+  white-space: nowrap;
+}
+.section-head__line {
+  flex: 1;
+  border-top: var(--hair) dotted var(--rule-strong);
+  transform: translateY(-0.3em);
+}
+.section-head__link {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: var(--track-meta);
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  white-space: nowrap;
+}
+.section-head__link:hover {
+  color: var(--accent);
+}
+
+/* ============================================================
+   HOME — IDENTITY
+   ============================================================ */
+.identity {
+  padding: var(--sp-9) 0 var(--sp-7);
+}
+.identity__name {
+  font-family: var(--font-serif);
+  font-weight: 500;
+  font-size: var(--fs-display);
+  line-height: var(--lh-tight);
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+.identity__tagline {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--ink-faint);
+  letter-spacing: 0.02em;
+  margin: var(--sp-3) 0 0;
+}
+.iam {
+  list-style: none;
+  margin: var(--sp-6) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+.iam li {
+  display: flex;
+  align-items: baseline;
+  gap: 0.85em;
+  font-size: 1.0625rem;
+  color: var(--ink-muted);
+}
+.iam .glyph {
+  flex: none;
+  width: 1.4em;
+  color: var(--ink-faint);
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  text-align: center;
+  transform: translateY(-0.05em);
+  display: inline-grid;
+  place-items: center;
+}
+.iam .glyph svg {
+  width: 1em;
+  height: 1em;
+}
+.iam a {
+  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-color: var(--rule-strong);
+  text-underline-offset: 3px;
+}
+.iam a:hover {
+  color: var(--accent);
+  text-decoration-color: var(--accent);
+}
+.socials {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+}
+.socials a {
+  display: inline-grid;
+  place-items: center;
+  width: 1.7em;
+  height: 1.7em;
+  color: var(--ink-muted);
+  border: var(--hair) solid var(--rule-strong);
+  border-radius: var(--radius);
+  text-decoration: none;
+  vertical-align: middle;
+}
+.socials a:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.socials svg {
+  width: 0.92em;
+  height: 0.92em;
+}
+.handle {
+  color: var(--accent);
+}
+
+/* ============================================================
+   DOT-LEADER LIST  (title ···· date)
+   ============================================================ */
+.leaders {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.leaders li {
+  margin: 0;
+}
+.leader {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6em;
+  padding: var(--sp-3) 0;
+  line-height: 1.4;
+}
+.leader__title {
+  font-family: var(--font-body);
+  font-size: 1.0625rem;
+  color: var(--ink);
+  text-decoration: none;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+.leader__title:hover {
+  color: var(--accent);
+}
+.leader__title:hover + .leader__dots {
+  border-color: var(--accent);
+  opacity: 0.6;
+}
+.leader__dots {
+  flex: 1 1 auto;
+  align-self: stretch;
+  border-bottom: 2px dotted var(--rule-strong);
+  transform: translateY(-0.32em);
+  min-width: 1.5em;
+}
+.leader__date {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: 0.04em;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.leader__draft {
+  color: var(--accent);
+}
+
+/* year group */
+.year-group {
+  margin-bottom: var(--sp-6);
+}
+.year-group__head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-1);
+}
+.year-group__year {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: var(--track-wide);
+  color: var(--accent);
+  font-weight: 700;
+}
+.year-group__count {
+  font-family: var(--font-mono);
+  font-size: var(--fs-micro);
+  color: var(--ink-faint);
+  letter-spacing: var(--track-meta);
+}
+
+/* ============================================================
+   NOTES
+   ============================================================ */
+.notes {
+  display: flex;
+  flex-direction: column;
+}
+.notes .note {
+  padding: var(--sp-5) 0;
+  border-top: var(--hair) dotted var(--rule);
+}
+.notes .note:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+.note__time {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: var(--sp-2);
+  display: block;
+}
+.note__title {
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 1.1rem;
+  margin: 0 0 var(--sp-2);
+  color: var(--ink);
+}
+.note__title a {
+  color: var(--ink);
+}
+.note__title a:hover {
+  color: var(--accent);
+}
+.note__body {
+  font-family: var(--font-cjk);
+  color: var(--ink-muted);
+  font-size: 1.0625rem;
+  line-height: var(--lh-cjk);
+  margin: 0;
+}
+.note__body > * {
+  margin: 0;
+}
+.note__body > * + * {
+  margin-top: var(--sp-3);
+}
+.note__body a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.note__body--clamp {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* note card (single, framed) */
+.note-card {
+  border: var(--hair) solid var(--rule-strong);
+  border-radius: var(--radius);
+  padding: var(--sp-5);
+  background: var(--paper-raised);
+}
+.note-card .note__body {
+  color: var(--ink);
+}
+
+/* ============================================================
+   ARTICLE
+   ============================================================ */
+.article-header {
+  padding: var(--sp-7) 0 0;
+}
+.article-header .backlink {
+  margin-bottom: var(--sp-5);
+}
+.article-cover {
+  margin: var(--sp-6) 0 0;
+}
+.article-cover img {
+  width: 100%;
+  border: var(--hair) solid var(--rule-strong);
+  border-radius: var(--radius);
+}
+.article-title {
+  /* Newsreader for Latin; CJK falls through to LXGW WenKai Lite via the stack */
+  font-family: var(--font-serif);
+  font-weight: 500;
+  font-size: var(--fs-h1);
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  margin: var(--sp-4) 0 var(--sp-4);
+  color: var(--ink);
+  text-wrap: pretty;
+}
+.article-meta {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5em;
+}
+.article-meta .dot {
+  color: var(--rule-strong);
+}
+.article-meta a {
+  color: var(--ink-muted);
+}
+.article-meta a:hover {
+  color: var(--accent);
+}
+.article-updated {
+  color: var(--accent);
+}
+.tag-chip {
+  color: var(--accent);
+}
+.tag-chip::before {
+  content: "#";
+  opacity: 0.6;
+}
+
+/* article wrapper — narrow (reading) by default, wider when the TOC rail shows */
+.article-wrap {
+  margin-inline: auto;
+  max-width: var(--measure);
+}
+@media (min-width: 1080px) {
+  .article-wrap {
+    max-width: 61rem;
+  }
+}
+
+/* article layout with right rail TOC */
+.article-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--sp-7);
+  padding: var(--sp-7) 0 var(--sp-9);
+}
+@media (min-width: 1080px) {
+  .article-layout {
+    grid-template-columns: minmax(0, 1fr) 15rem;
+  }
+}
+
+/* ---- TOC ---- */
+.toc {
+  position: sticky;
+  top: var(--sp-6);
+  align-self: start;
+  display: none;
+}
+@media (min-width: 1080px) {
+  .toc {
+    display: block;
+  }
+}
+.toc__label {
+  font-family: var(--font-mono);
+  font-size: var(--fs-micro);
+  letter-spacing: var(--track-meta);
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: var(--sp-3);
+}
+.toc ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-left: var(--hair) solid var(--rule);
+}
+.toc li {
+  margin: 0;
+}
+.toc a {
+  display: block;
+  padding: 0.35em 0 0.35em 0.9em;
+  margin-left: -1px;
+  border-left: 2px solid transparent;
+  font-size: var(--fs-sm);
+  line-height: 1.4;
+  color: var(--ink-muted);
+}
+.toc a:hover {
+  color: var(--ink);
+}
+.toc a.is-active {
+  color: var(--accent);
+  border-left-color: var(--accent);
+}
+.toc a.toc-h3 {
+  padding-left: 1.8em;
+  font-size: var(--fs-micro);
+}
+
+/* ============================================================
+   PROSE  (overrides @tailwindcss/typography's :where rules)
+   ============================================================ */
+.prose {
+  max-width: var(--measure);
+  font-family: var(--font-body);
+  font-size: var(--fs-body);
+  line-height: var(--lh-cjk);
+  color: var(--ink);
+}
+.prose > * + * {
+  margin-top: var(--sp-5);
+}
+.prose p {
+  margin: 0;
+  text-wrap: pretty;
+}
+
+.prose :is(h1, h2, h3, h4, h5, h6) {
+  /* Newsreader for Latin; CJK falls through to LXGW WenKai Lite via the stack */
+  font-family: var(--font-serif);
+  color: var(--ink);
+  line-height: var(--lh-snug);
+  letter-spacing: -0.01em;
+  scroll-margin-top: var(--sp-6);
+}
+.prose h2 {
+  font-size: var(--fs-h2);
+  font-weight: 500;
+  margin-top: var(--sp-7);
+  padding-top: var(--sp-4);
+  border-top: var(--hair) dotted var(--rule-strong);
+}
+.prose h3 {
+  font-size: var(--fs-h3);
+  font-weight: 600;
+  margin-top: var(--sp-6);
+}
+.prose h4 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-top: var(--sp-5);
+}
+/* autolinked headings (rehype-autolink-headings wrap) */
+.prose :is(h1, h2, h3, h4, h5, h6) a {
+  color: inherit;
+  text-decoration: none;
+}
+.prose :is(h2, h3, h4):hover a::before {
+  content: "#";
+  position: absolute;
+  margin-left: -1.1em;
+  color: var(--ink-faint);
+}
+@media (max-width: 640px) {
+  .prose :is(h2, h3, h4):hover a::before {
+    content: none;
+  }
+}
+
+.prose a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  text-decoration-color: color-mix(in oklab, var(--accent) 45%, transparent);
+}
+.prose a:hover {
+  text-decoration-color: var(--accent);
+  color: var(--accent);
+}
+
+.prose strong {
+  font-weight: 700;
+  color: var(--ink);
+}
+.prose em {
+  font-style: italic;
+}
+
+.prose ul,
+.prose ol {
+  margin: var(--sp-5) 0;
+  padding-left: 1.6em;
+}
+.prose ul {
+  list-style: disc;
+}
+.prose ol {
+  list-style: decimal;
+}
+.prose li {
+  margin: 0.4em 0;
+  padding-left: 0.2em;
+}
+.prose li::marker {
+  color: var(--ink-faint);
+}
+
+.prose blockquote {
+  margin: var(--sp-6) 0;
+  padding: 0.2em 0 0.2em 1.4em;
+  border-left: 2px solid var(--accent);
+  color: var(--ink-muted);
+}
+.prose blockquote p {
+  margin: 0;
+}
+
+/* inline code chip (block code handled by expressive-code) */
+.prose :not(pre) > code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--code-bg);
+  border: var(--hair) solid var(--rule);
+  border-radius: var(--radius);
+  padding: 0.12em 0.4em;
+  color: var(--ink);
+}
+
+/* figure / image */
+.prose figure {
+  margin: var(--sp-6) 0;
+}
+.prose :where(p, figure) img {
+  width: 100%;
+  border: var(--hair) solid var(--rule-strong);
+  border-radius: var(--radius);
+}
+.prose figcaption {
+  margin-top: var(--sp-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: 0.02em;
+  color: var(--ink-faint);
+  font-style: italic;
+  text-align: center;
+}
+
+/* table */
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--fs-sm);
+  margin: var(--sp-6) 0;
+  display: block;
+  overflow-x: auto;
+}
+.prose th,
+.prose td {
+  text-align: left;
+  padding: 0.6em 0.8em;
+  border-bottom: var(--hair) solid var(--rule);
+  vertical-align: top;
+}
+.prose thead th {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  border-bottom: var(--hair) solid var(--rule-strong);
+  font-weight: 400;
+}
+.prose tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+/* footnotes */
+.prose .footnotes {
+  margin-top: var(--sp-8);
+  padding-top: var(--sp-5);
+  border-top: var(--hair) dotted var(--rule-strong);
+  font-size: var(--fs-sm);
+  color: var(--ink-muted);
+}
+.prose sup a {
+  text-decoration: none;
+}
+
+/* expressive-code blocks: sit in the prose flow, on-brand frame */
+.prose .expressive-code {
+  margin: var(--sp-6) 0;
+}
+.expressive-code .frame pre {
+  border-radius: var(--radius);
+  border: var(--hair) solid var(--rule-strong);
+}
+
+/* katex display math scrolls instead of overflowing */
+.prose .katex-display {
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 0.2em 0;
+}
+
+/* ============================================================
+   TAG LIST / CHIPS
+   ============================================================ */
+.taglist {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+}
+.tag {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: 0.04em;
+  color: var(--ink-muted);
+  border: var(--hair) solid var(--rule-strong);
+  border-radius: var(--radius);
+  padding: 0.3em 0.65em;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3em;
+}
+.tag:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.tag .hash {
+  color: var(--ink-faint);
+}
+.tag .ct {
+  color: var(--ink-faint);
+  font-size: 0.85em;
+}
+.tag:hover .hash {
+  color: var(--accent);
+}
+
+/* rss link */
+.rss {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: var(--track-meta);
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+}
+.rss:hover {
+  color: var(--accent);
+}
+.rss svg {
+  width: 13px;
+  height: 13px;
+}
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+.site-footer {
+  position: relative;
+  z-index: 1;
+  margin-top: var(--sp-9);
+}
+.site-footer__inner {
+  border-top: var(--hair) dotted var(--rule-strong);
+  padding: var(--sp-5) 0 var(--sp-7);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: 0.04em;
+  color: var(--ink-faint);
+}
+.site-footer a {
+  color: var(--ink-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+}
+.site-footer a:hover {
+  color: var(--accent);
+}
+.site-footer svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* ============================================================
+   PAGE TITLE BLOCK (posts/about/tag/404)
+   ============================================================ */
+.page-head {
+  padding: var(--sp-8) 0 var(--sp-6);
+}
+.page-head__title {
+  font-family: var(--font-serif);
+  font-weight: 500;
+  font-size: var(--fs-h1);
+  line-height: var(--lh-tight);
+  letter-spacing: -0.02em;
+  margin: var(--sp-3) 0 0;
+}
+.page-head__sub {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--ink-faint);
+  margin: var(--sp-3) 0 0;
+}
+
+/* two-column index layout (posts: list + sidebar) */
+.index-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--sp-7);
+  padding-bottom: var(--sp-8);
+}
+@media (min-width: 940px) {
+  .index-layout {
+    grid-template-columns: minmax(0, 1fr) 14rem;
+  }
+}
+.index-side {
+  align-self: start;
+}
+@media (min-width: 940px) {
+  .index-side {
+    position: sticky;
+    top: var(--sp-6);
+  }
+}
+
+/* 404 */
+.bigcode {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: clamp(4rem, 18vw, 9rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: var(--ink);
+}
+
+/* pagination */
+.paginator {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  margin-top: var(--sp-7);
+  padding-top: var(--sp-5);
+  border-top: var(--hair) dotted var(--rule-strong);
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: var(--track-meta);
+  text-transform: uppercase;
+}
+.paginator a {
+  color: var(--ink-muted);
+}
+.paginator a:hover {
+  color: var(--accent);
+}
+.paginator__next {
+  margin-left: auto;
+}
+
+/* generic stack helpers */
+.stack-5 > * + * {
+  margin-top: var(--sp-5);
+}
+.stack-6 > * + * {
+  margin-top: var(--sp-6);
+}
+.stack-7 > * + * {
+  margin-top: var(--sp-7);
+}
+
+/* ============================================================
+   BACK-TO-TOP BUTTON
+   ============================================================ */
+.to-top {
+  position: fixed;
+  right: var(--sp-5);
+  bottom: var(--sp-6);
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border: var(--hair) solid var(--rule-strong);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+  color: var(--ink-muted);
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(8px);
+  transition:
+    opacity 0.25s,
+    transform 0.25s,
+    color 0.2s,
+    border-color 0.2s;
+  pointer-events: none;
+}
+.to-top[data-show="true"] {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+.to-top:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.to-top svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* ============================================================
+   ADMONITIONS  (remark-admonitions)
+   ============================================================ */
+.admonition {
+  --admonition-color: var(--accent);
+  margin: var(--sp-5) 0;
+  border-left: 2px solid var(--admonition-color);
+  padding: var(--sp-4) 0 var(--sp-4) var(--sp-4);
+}
+.admonition .admonition-title {
+  margin: 0 0 var(--sp-2);
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  letter-spacing: var(--track-meta);
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--admonition-color);
+}
+.admonition .admonition-title::before {
+  content: "";
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  flex: none;
+  background: var(--admonition-color);
+  mask-size: contain;
+  mask-position: center;
+  mask-repeat: no-repeat;
+}
+.admonition .admonition-content > :last-child {
+  margin-bottom: 0;
+}
+.admonition[data-admonition-type="note"] {
+  --admonition-color: #4a90d9;
+}
+.admonition[data-admonition-type="tip"] {
+  --admonition-color: #5a9e54;
+}
+.admonition[data-admonition-type="important"] {
+  --admonition-color: #8a63d2;
+}
+.admonition[data-admonition-type="caution"] {
+  --admonition-color: #cc8a3a;
+}
+.admonition[data-admonition-type="warning"] {
+  --admonition-color: #cc4a3a;
+}
+.admonition[data-admonition-type="note"] .admonition-title::before {
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E");
+}
+.admonition[data-admonition-type="tip"] .admonition-title::before {
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z'/%3E%3C/svg%3E");
+}
+.admonition[data-admonition-type="important"] .admonition-title::before {
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E");
+}
+.admonition[data-admonition-type="caution"] .admonition-title::before {
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E");
+}
+.admonition[data-admonition-type="warning"] .admonition-title::before {
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E");
+}
+
+/* ============================================================
+   A11Y
+   ============================================================ */
+.visually-hidden,
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+.skip-link {
+  position: absolute;
+  left: var(--sp-4);
+  top: var(--sp-4);
+  z-index: 100;
+  transform: translateY(-200%);
+  background: var(--paper-raised);
+  border: var(--hair) solid var(--rule-strong);
+  border-radius: var(--radius);
+  padding: 0.5em 0.9em;
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  color: var(--ink);
+  transition: transform 0.2s;
+}
+.skip-link:focus {
+  transform: translateY(0);
 }
 
 * {
   scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
+  scrollbar-color: var(--rule-strong) transparent;
 }
 
-@layer components {
-  .cactus-link {
-    @apply hover:decoration-link underline underline-offset-2 hover:decoration-2;
+/* ============================================================
+   RESPONSIVE HEADER
+   ============================================================ */
+@media (max-width: 640px) {
+  .site-header__inner {
+    gap: var(--sp-4);
+    height: 56px;
   }
-
-  .title {
-    @apply text-accent-2 text-2xl font-semibold;
+  .search-btn .skb {
+    display: none;
   }
-
-  .admonition {
-    --admonition-color: var(--tw-prose-quotes);
-    @apply my-4 border-s-2 border-(--admonition-color) py-4 ps-4;
-
-    .admonition-title {
-      @apply my-0! flex items-center gap-2 text-sm font-bold text-(--admonition-color) capitalize;
-      &:before {
-        @apply inline-block h-4 w-4 shrink-0 overflow-visible bg-(--admonition-color) align-middle
-          content-[""];
-        mask-size: contain;
-        mask-position: center;
-        mask-repeat: no-repeat;
-      }
-    }
-
-    .admonition-content {
-      > :last-child {
-        @apply mb-0!;
-      }
-    }
-
-    &[data-admonition-type="note"] {
-      --admonition-color: var(--color-blue-400);
-      @apply bg-blue-400/5;
-
-      .admonition-title::before {
-        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' width='16' height='16' aria-hidden='true'%3E%3Cpath fill='var(--admonitions-color-tip)' d='M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'%3E%3C/path%3E%3C/svg%3E");
-      }
-    }
-
-    &[data-admonition-type="tip"] {
-      --admonition-color: var(--color-lime-500);
-      @apply bg-lime-500/5;
-
-      .admonition-title::before {
-        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' width='16' height='16' aria-hidden='true'%3E%3Cpath d='M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z'%3E%3C/path%3E%3C/svg%3E");
-      }
-    }
-
-    &[data-admonition-type="important"] {
-      --admonition-color: var(--color-purple-400);
-      @apply bg-purple-400/5;
-
-      .admonition-title::before {
-        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' width='16' height='16' aria-hidden='true'%3E%3Cpath d='M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'%3E%3C/path%3E%3C/svg%3E");
-      }
-    }
-
-    &[data-admonition-type="caution"] {
-      --admonition-color: var(--color-orange-400);
-      @apply bg-orange-400/5;
-
-      .admonition-title::before {
-        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' width='16' height='16' aria-hidden='true'%3E%3Cpath d='M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'%3E%3C/path%3E%3C/svg%3E");
-      }
-    }
-
-    &[data-admonition-type="warning"] {
-      --admonition-color: var(--color-red-500);
-      @apply bg-red-500/5;
-
-      .admonition-title::before {
-        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' width='16' height='16' aria-hidden='true'%3E%3Cpath d='M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'%3E%3C/path%3E%3C/svg%3E");
-      }
-    }
+  .nav {
+    gap: var(--sp-4);
+  }
+  .identity {
+    padding: var(--sp-7) 0 var(--sp-6);
+  }
+  .iam li {
+    font-size: 1rem;
   }
 }
-
-@utility prose {
-  --tw-prose-body: var(--color-foreground);
-  --tw-prose-bold: var(--color-foreground);
-  --tw-prose-bullets: var(--color-foreground);
-  --tw-prose-code: var(--color-foreground);
-  --tw-prose-headings: var(--color-accent-2);
-  --tw-prose-hr: 0.5px dashed #666;
-  --tw-prose-links: var(--color-foreground);
-  --tw-prose-quotes: var(--color-quote);
-  --tw-prose-th-borders: #666;
-
-  /* Serif body text: Latin renders in Newsreader, CJK falls through to LXGW
-     WenKai Lite. Code stays monospace (fenced blocks keep expressive-code's
-     own font; this only guards inline code/kbd/samp). */
-  font-family: var(--font-serif);
-
-  :where(code, kbd, samp) {
-    font-family: var(--font-mono);
+@media (max-width: 460px) {
+  .wordmark .label-text {
+    display: none;
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -883,6 +883,8 @@ hr {
   font-size: var(--fs-body);
   line-height: var(--lh-cjk);
   color: var(--ink);
+  /* wrap long unbroken tokens (URLs, code) instead of overflowing the column */
+  overflow-wrap: break-word;
 }
 .prose > * + * {
   margin-top: var(--sp-5);


### PR DESCRIPTION
A complete visual overhaul of the site, moving from the old monospace-everywhere
theme to a refined **editorial** look inspired by [zed.dev/blog](https://zed.dev/blog)
and [ampcode.com/chronicle](https://ampcode.com/chronicle).

## Process
- Reviewed the current site + both references in-browser, then drove the
  **claude.ai/design** tool (prompt + screenshots) to generate a full design system
  and 8 screens, iterated on it, and ported the result to Astro.
- Extracted the generated `styles.css` / `site.js` as the source of truth for exact
  tokens, then re-implemented idiomatically in the existing Astro + Tailwind v4 setup.

## Type system
- **Display** (hero, titles, headings): Newsreader (Latin) → LXGW WenKai Lite (CJK),
  via one font stack so mixed CJK/Latin pairs correctly.
- **Body / prose**: Geist (Latin) → system CJK sans (PingFang/YaHei/Noto Sans SC).
- **Chrome** (nav, labels, dates, meta): iA Writer Mono.

## Look
- Near-monochrome palette + a single **amber** accent (warm paper in light, true
  warm-charcoal — never navy — in dark; theme follows system, persists on toggle).
- Fixed dotted **guide lines** + faint graph-paper margins, **dot-leader** post lists,
  mono small-caps section labels, sticky "On this page" TOC with scrollspy.

## What changed
- `global.css` rebuilt as a token-driven system; Pagefind search re-themed.
- Header / footer / theme toggle / shell rebuilt.
- Every page rebuilt: home, posts index, article, notes, about, tag, 404 + paginator.
- Routes, content schema, Pagefind, webmentions, KaTeX and OG images left intact.

## Verification
- `pnpm build` ✓ (1092 pages, Pagefind indexes 222), `astro check` 0 errors,
  prettier + eslint + autocorrect clean.
- Reviewed every page in **light + dark** and at **desktop + mobile** widths:
  prose (headings, lists, blockquotes, tables), expressive-code blocks, KaTeX math,
  the TOC scrollspy, back-to-top, and search all verified.

## Notes for review
- The About bio copy and the single Notes entry are tasteful placeholders — edit to taste.
- The amber accent was chosen per your call; it's a single token (`--accent`) if you
  want to retune it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)