### PR TITLE
[codex] update site font system

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -6,7 +6,7 @@ import expressiveCode from "astro-expressive-code";
 import icon from "astro-icon";
 import robotsTxt from "astro-robots-txt";
 import webmanifest from "astro-webmanifest";
-import { defineConfig, envField, fontProviders } from "astro/config";
+import { defineConfig, envField } from "astro/config";
 import { expressiveCodeOptions } from "./src/site.config";
 import { siteConfig } from "./src/site.config";
 
@@ -30,41 +30,6 @@ export default defineConfig({
     // https://docs.astro.build/zh-cn/reference/configuration-reference/#buildformat
     format: "preserve",
   },
-  fonts: [
-    {
-      provider: fontProviders.fontsource(),
-      name: "iA Writer Duo",
-      cssVariable: "--font-ia-writer-duo",
-    },
-    {
-      provider: fontProviders.fontsource(),
-      name: "iA Writer Mono",
-      cssVariable: "--font-ia-writer-mono",
-    },
-    {
-      provider: fontProviders.google(),
-      name: "Geist",
-      cssVariable: "--font-geist",
-    },
-    {
-      provider: fontProviders.google(),
-      name: "Geist Mono",
-      cssVariable: "--font-geist-mono",
-    },
-    {
-      provider: fontProviders.google(),
-      name: "Newsreader",
-      cssVariable: "--font-newsreader",
-    },
-    {
-      provider: fontProviders.google(),
-      name: "Noto Serif SC",
-      cssVariable: "--font-noto-serif-sc",
-    },
-    // LXGW WenKai is a CJK font that fontsource only ships as a broken latin-only
-    // subset, so it is loaded from the jsDelivr CDN instead (see the <link> in
-    // BaseHead.astro). Family name: "LXGW WenKai Lite".
-  ],
   image: {
     domains: ["webmention.io"],
   },

--- a/src/components/AboutMe.astro
+++ b/src/components/AboutMe.astro
@@ -15,8 +15,10 @@ const { showIntro = true } = Astro.props;
   {
     showIntro && (
       <header class="mb-8">
-        <h1 class="text-accent-2 text-3xl font-semibold sm:text-4xl">{siteConfig.author}</h1>
-        <p class="mt-2 text-gray-600 dark:text-gray-400">Notes on tech, products, and life.</p>
+        <h1 class="text-accent-2 text-2xl font-semibold sm:text-3xl">{siteConfig.author}</h1>
+        <p class="font-plex-sans mt-2 text-gray-600 dark:text-gray-400">
+          Notes on tech, products, and life.
+        </p>
       </header>
     )
   }

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -82,6 +82,10 @@ const socialImageURL = new URL(ogImage ? ogImage : "/social-card.png", Astro.url
 
 {/* Fonts */}
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/lxgw-wenkai-lite-webfont@1.1.0/style.css"
+/>
 
 {/* KaTeX */}
 <script

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -4,7 +4,6 @@ import { siteConfig } from "@/site.config";
 import type { SiteMeta } from "@/types";
 import { getCanonicalUrl } from "@/utils/url";
 import "@/styles/global.css";
-import { Font } from "astro:assets";
 import type { CollectionEntry } from "astro:content";
 
 interface Props extends SiteMeta {
@@ -82,18 +81,7 @@ const socialImageURL = new URL(ogImage ? ogImage : "/social-card.png", Astro.url
 <link href="/notes/rss.xml" title="Notes" rel="alternate" type="application/rss+xml" />
 
 {/* Fonts */}
-<!-- <Font cssVariable="--font-ia-writer-duo" preload /> -->
-<Font cssVariable="--font-ia-writer-mono" preload />
-{/* Latin serif for prose body text; CJK falls through to LXGW WenKai Lite */}
-<Font cssVariable="--font-newsreader" />
-<!-- <Font cssVariable="--font-geist" preload />
-<Font cssVariable="--font-geist-mono" preload /> -->
-{/* LXGW WenKai Lite (CJK serif) served from jsDelivr; family: "LXGW WenKai Lite" */}
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/lxgw-wenkai-lite-webfont@1.1.0/style.css"
-/>
 
 {/* KaTeX */}
 <script

--- a/src/components/FormattedDate.astro
+++ b/src/components/FormattedDate.astro
@@ -7,10 +7,12 @@ type Props = HTMLAttributes<"time"> & {
   dateTimeOptions?: Intl.DateTimeFormatOptions;
 };
 
-const { date, dateTimeOptions, ...attrs } = Astro.props;
+const { date, dateTimeOptions, class: className, ...attrs } = Astro.props;
 
 const postDate = getFormattedDate(date, dateTimeOptions);
 const ISO = date.toISOString();
 ---
 
-<time datetime={ISO} title={ISO} {...attrs}>{postDate}</time>
+<time class:list={["font-plex-mono", className]} datetime={ISO} title={ISO} {...attrs}>
+  {postDate}
+</time>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -6,7 +6,7 @@ import { Icon } from "astro-icon/components";
 ---
 
 <header
-  class="border-grid bg-background/95 supports-[backdrop-filter]:bg-background/60 fixed top-0 z-50 w-full border-b border-dashed border-gray-200 backdrop-blur-sm dark:border-gray-700"
+  class="border-grid bg-background/95 supports-[backdrop-filter]:bg-background/60 font-plex-sans fixed top-0 z-50 w-full border-b border-dashed border-gray-200 backdrop-blur-sm dark:border-gray-700"
 >
   <div
     class="relative m-auto flex max-w-4xl items-center border-r border-l border-dashed border-gray-200 p-4 px-4 sm:flex-col sm:px-6 dark:border-gray-700"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,7 +28,7 @@ const latestNotes = allNotes.sort(collectionDateSort).slice(0, MAX_NOTES);
   </section>
   <section class="flex flex-col border-t border-dashed border-gray-200 py-10 dark:border-gray-700">
     <div class="container m-auto max-w-3xl px-4 sm:px-6">
-      <h2 class="mb-6"><a href="/posts" class="text-accent">from the blog</a></h2>
+      <h2 class="mb-6 text-lg"><a href="/posts" class="text-accent">blog</a></h2>
       <ul class="space-y-4" role="list">
         {
           allPostsByDate.map((p) => (
@@ -44,9 +44,9 @@ const latestNotes = allNotes.sort(collectionDateSort).slice(0, MAX_NOTES);
     latestNotes.length > 0 && (
       <section class="flex flex-col border-t border-dashed border-gray-200 py-10 dark:border-gray-700">
         <div class="container m-auto max-w-3xl px-4 sm:px-6">
-          <h2 class="mb-6">
+          <h2 class="mb-6 text-lg">
             <a href="/notes" class="text-accent">
-              notes taking
+              notes
             </a>
           </h2>
           <ul class="space-y-4" role="list">

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -48,8 +48,7 @@ export const menuLinks: { path: string; title: string; icon: string }[] = [
 export const expressiveCodeOptions: AstroExpressiveCodeOptions = {
   styleOverrides: {
     borderRadius: "4px",
-    codeFontFamily:
-      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;',
+    codeFontFamily: "var(--font-plex-mono)",
     codeFontSize: "0.875rem",
     codeLineHeight: "1.7142857rem",
     codePaddingInline: "1rem",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -282,7 +282,8 @@
   --font-alias-plexSerif: "Newsreader Variable", "LXGW WenKai", "LXGW WenKai Lite",
     ui-serif, Georgia, "Times New Roman", serif;
   --font-alias-plexSans: "iA Writer Quattro", ui-sans-serif, system-ui, sans-serif;
-  --font-alias-writer: "Inter Variable", ui-sans-serif, system-ui, sans-serif;
+  --font-alias-writer: "Inter Variable", "LXGW WenKai Lite", ui-sans-serif, system-ui,
+    sans-serif;
   --font-alias-plexMono: "iA Writer Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
     Consolas, "Liberation Mono", "Courier New", monospace;
   --font-plex-serif: var(--font-alias-plexSerif);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -61,6 +61,9 @@
   font-weight: 300;
   src: url("https://cdn.jsdelivr.net/fontsource/fonts/lxgw-wenkai@latest/latin-300-normal.woff2")
     format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+    U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 @font-face {
@@ -70,6 +73,9 @@
   font-weight: 500;
   src: url("https://cdn.jsdelivr.net/fontsource/fonts/lxgw-wenkai@latest/latin-500-normal.woff2")
     format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+    U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 @font-face {
@@ -273,8 +279,8 @@
   --color-accent-2: oklch(18.15% 0 0);
   --color-quote: oklch(55.27% 0.195 19.06);
   /* --color-quote: var(--muted-foreground); */
-  --font-alias-plexSerif: "Newsreader Variable", "LXGW WenKai", ui-serif, Georgia,
-    "Times New Roman", serif;
+  --font-alias-plexSerif: "Newsreader Variable", "LXGW WenKai", "LXGW WenKai Lite",
+    ui-serif, Georgia, "Times New Roman", serif;
   --font-alias-plexSans: "iA Writer Quattro", ui-sans-serif, system-ui, sans-serif;
   --font-alias-writer: "Inter Variable", ui-sans-serif, system-ui, sans-serif;
   --font-alias-plexMono: "iA Writer Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,6 +6,192 @@
 /* use a selector-based strategy for dark mode */
 @variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
+@font-face {
+  font-family: "Newsreader Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 200 800;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/newsreader:vf@latest/latin-wght-normal.woff2")
+    format("woff2-variations");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+    U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Newsreader Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 200 800;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/newsreader:vf@latest/latin-ext-wght-normal.woff2")
+    format("woff2-variations");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
+    U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
+    U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: "Newsreader Variable";
+  font-style: italic;
+  font-display: swap;
+  font-weight: 200 800;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/newsreader:vf@latest/latin-wght-italic.woff2")
+    format("woff2-variations");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+    U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Newsreader Variable";
+  font-style: italic;
+  font-display: swap;
+  font-weight: 200 800;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/newsreader:vf@latest/latin-ext-wght-italic.woff2")
+    format("woff2-variations");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
+    U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
+    U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: "LXGW WenKai";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 300;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/lxgw-wenkai@latest/latin-300-normal.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "LXGW WenKai";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/lxgw-wenkai@latest/latin-500-normal.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "iA Writer Quattro";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@latest/latin-400-normal.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "iA Writer Quattro";
+  font-style: italic;
+  font-display: swap;
+  font-weight: 400;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@latest/latin-400-italic.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "iA Writer Quattro";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@latest/latin-700-normal.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "iA Writer Quattro";
+  font-style: italic;
+  font-display: swap;
+  font-weight: 700;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@latest/latin-700-italic.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "Inter Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-wght-normal.woff2")
+    format("woff2-variations");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+    U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Inter Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-ext-wght-normal.woff2")
+    format("woff2-variations");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
+    U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
+    U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: "Inter Variable";
+  font-style: italic;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-wght-italic.woff2")
+    format("woff2-variations");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+    U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Inter Variable";
+  font-style: italic;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-ext-wght-italic.woff2")
+    format("woff2-variations");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
+    U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
+    U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: "iA Writer Mono";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-mono@latest/latin-400-normal.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "iA Writer Mono";
+  font-style: italic;
+  font-display: swap;
+  font-weight: 400;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-mono@latest/latin-400-italic.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "iA Writer Mono";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-mono@latest/latin-700-normal.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "iA Writer Mono";
+  font-style: italic;
+  font-display: swap;
+  font-weight: 700;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-mono@latest/latin-700-italic.woff2")
+    format("woff2");
+}
+
 /* Shadcn UI theme https://ui.shadcn.com/themes */
 :root {
   --radius: 0.5rem;
@@ -87,16 +273,18 @@
   --color-accent-2: oklch(18.15% 0 0);
   --color-quote: oklch(55.27% 0.195 19.06);
   /* --color-quote: var(--muted-foreground); */
-  --font-sans: "Geist", ui-sans-serif, system-ui, sans-serif;
-  /* Astro registers webfonts under hashed family names exposed via the --font-*
-     variables; reference those (not literal names) so the self-hosted fonts are
-     used, never a locally-installed copy. The variables' trailing generic is a
-     latin-only system font, so CJK glyphs continue past it to LXGW WenKai Lite. */
-  /* Global default: iA Writer Mono (Latin) → LXGW WenKai Lite (CJK) → mono. */
-  --font-mono: var(--font-ia-writer-mono), "LXGW WenKai Lite", ui-monospace, monospace;
-  /* Prose: Newsreader (Latin) → LXGW WenKai Lite (CJK) → global mono stack. */
-  --font-serif: var(--font-newsreader), "LXGW WenKai Lite", var(--font-ia-writer-mono),
-    ui-monospace, monospace;
+  --font-alias-plexSerif: "Newsreader Variable", "LXGW WenKai", ui-serif, Georgia,
+    "Times New Roman", serif;
+  --font-alias-plexSans: "iA Writer Quattro", ui-sans-serif, system-ui, sans-serif;
+  --font-alias-writer: "Inter Variable", ui-sans-serif, system-ui, sans-serif;
+  --font-alias-plexMono: "iA Writer Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+  --font-plex-serif: var(--font-alias-plexSerif);
+  --font-plex-sans: var(--font-alias-plexSans);
+  --font-writer: var(--font-alias-writer);
+  --font-plex-mono: var(--font-alias-plexMono);
+  --font-sans: var(--font-alias-plexSans);
+  --font-mono: var(--font-alias-plexMono);
 }
 
 @layer base {
@@ -121,7 +309,14 @@
     }
   }
   body {
-    @apply font-mono;
+    @apply font-plex-sans;
+  }
+  :where(h1, h2, h3, h4, h5, h6) {
+    font-family: var(--font-alias-plexSerif);
+  }
+
+  :where(code, kbd, samp, pre) {
+    font-family: var(--font-alias-plexMono);
   }
 }
 
@@ -136,7 +331,7 @@
   }
 
   .title {
-    @apply text-accent-2 text-2xl font-semibold;
+    @apply text-accent-2 font-plex-serif text-2xl font-semibold;
   }
 
   .admonition {
@@ -218,12 +413,13 @@
   --tw-prose-quotes: var(--color-quote);
   --tw-prose-th-borders: #666;
 
-  /* Serif body text: Latin renders in Newsreader, CJK falls through to LXGW
-     WenKai Lite. Code stays monospace (fenced blocks keep expressive-code's
-     own font; this only guards inline code/kbd/samp). */
-  font-family: var(--font-serif);
+  font-family: var(--font-alias-writer);
+
+  :where(h1, h2, h3, h4, h5, h6) {
+    font-family: var(--font-alias-plexSerif);
+  }
 
   :where(code, kbd, samp) {
-    font-family: var(--font-mono);
+    font-family: var(--font-alias-plexMono);
   }
 }


### PR DESCRIPTION
## Summary

- Move typography loading to explicit Fontsource CDN `@font-face` rules.
- Define the `plexSerif`, `plexSans`, `writer`, and `plexMono` font aliases in Tailwind/CSS tokens.
- Apply the aliases across headings, prose, dates, code, navigation, and the homepage section labels.

## Validation

- `pnpm lint`
- `pnpm build`