### PR TITLE
[codex] add code review workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,26 @@
+name: Code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  code-review:
+    if: >-
+      github.event.pull_request &&
+      !github.event.pull_request.draft &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: taptap/.github/.github/workflows/code-review.yml@v1
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      is_draft: ${{ github.event.pull_request.draft }}
+      head_repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

Adds the shared Code Review GitHub Actions workflow copied from `xdanger/typescript-scaffold`.

## Impact

Pull requests from branches in this repository will run the reusable `taptap/.github` code review workflow when they are not drafts.

## Validation

- `git diff --check`
- `pnpm exec prettier --check .github/workflows/code-review.yml`