### PR TITLE
[codex] tune site surface colors

### DIFF
--- a/src/components/note/Note.astro
+++ b/src/components/note/Note.astro
@@ -13,9 +13,7 @@ const { Content } = await render(note);
 ---
 
 <article
-  class:list={[
-    isPreview && "inline-grid rounded-md bg-[rgb(240,240,240)] px-4 py-3 dark:bg-[rgb(33,35,38)]",
-  ]}
+  class:list={[isPreview && "inline-grid rounded-md bg-white/75 px-4 py-3 dark:bg-white/5"]}
   data-pagefind-body={isPreview ? false : true}
 >
   <Tag class="title" class:list={{ "text-base": isPreview }}>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -201,7 +201,7 @@
 /* Shadcn UI theme https://ui.shadcn.com/themes */
 :root {
   --radius: 0.5rem;
-  --background: oklch(98.48% 0 0);
+  --background: oklch(98.79% 0.0045 34.31);
   --foreground: oklch(0.141 0.005 285.823); /* oklch(26.99% 0.0096 235.05) */
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.141 0.005 285.823);


### PR DESCRIPTION
## Summary

- Align the light page background with the Zed Terminal paper color.
- Soften note preview cards with translucent white surfaces.

## Validation

- `pnpm exec prettier --write src/styles/global.css`
- `pnpm exec prettier --write src/components/note/Note.astro`
- `pnpm exec eslint --fix src/components/note/Note.astro`
- `pnpm exec autocorrect --fix src/components/note/Note.astro`
- `pnpm build`