### PR TITLE
✨ feat(site): polish blog chrome

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,428 @@
+Attribution-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
+
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
+
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+     including for purposes of Section 3(b); and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/README.md
+++ b/README.md
@@ -113,5 +113,5 @@ pnpm install
 
 ## LICENSE
 
-- 代码部分：遵循 Astro 的 MIT 协议
-- 文章内容：采用 [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)
+本仓库采用 [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) 授权，详见
+[`LICENSE`](./LICENSE)。第三方依赖和 `public/assets/` 中保留的第三方素材仍遵循其各自的上游许可。

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@astrojs/check": "^0.9.9",
     "@eslint/js": "^10.0.1",
     "@iconify-json/fa6-brands": "^1.2.6",
+    "@iconify-json/line-md": "^1.2.16",
     "@iconify-json/material-symbols-light": "^1.2.75",
     "@iconify-json/mdi": "^1.2.3",
     "@iconify-json/solar": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "eccentric-event",
   "version": "6.2.0",
+  "license": "CC-BY-SA-4.0",
   "type": "module",
   "packageManager": "pnpm@10.33.4",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@iconify-json/fa6-brands':
         specifier: ^1.2.6
         version: 1.2.6
+      '@iconify-json/line-md':
+        specifier: ^1.2.16
+        version: 1.2.16
       '@iconify-json/material-symbols-light':
         specifier: ^1.2.75
         version: 1.2.75
@@ -546,6 +549,9 @@ packages:
 
   '@iconify-json/fa6-brands@1.2.6':
     resolution: {integrity: sha512-twL3X4KWcxAhbc1vz/mIDsVr+CAItk1/EIfxKUVQtpv6O4eydk5KNYqTZWdvJNHGInUgd6vKg21aWfVgb5DXEg==}
+
+  '@iconify-json/line-md@1.2.16':
+    resolution: {integrity: sha512-esHPUQUp30NyqJWa7MNu6ExdG8z/aEFC5r56rVyRGhtJ7acOme6YtYPnDOgVu6p+kk24rM8602xkFuBC6g6x+w==}
 
   '@iconify-json/material-symbols-light@1.2.75':
     resolution: {integrity: sha512-YapyS2x6BoADGR3OUjmRavrwjE5VyVLyky1cyokGA4el0Km5RSJsfvvrnTsK5bomZZGFCP0bBH6hokk2Z6FeHg==}
@@ -4391,6 +4397,10 @@ snapshots:
   '@humanwhocodes/retry@0.4.3': {}
 
   '@iconify-json/fa6-brands@1.2.6':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/line-md@1.2.16':
     dependencies:
       '@iconify/types': 2.0.0
 

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -23,6 +23,13 @@ import { Icon } from "astro-icon/components";
       const button = this.querySelector<HTMLButtonElement>("button");
 
       if (button) {
+        const replayIcon = () => {
+          const icon = button.querySelector("svg");
+          if (!icon) return;
+
+          icon.replaceWith(icon.cloneNode(true));
+        };
+
         const setLabel = () => {
           button.setAttribute(
             "aria-label",
@@ -44,6 +51,7 @@ import { Icon } from "astro-icon/components";
             },
           });
           document.dispatchEvent(themeChangeEvent);
+          replayIcon();
         });
       } else {
         console.warn("Theme Toggle: No button found");

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,11 +1,14 @@
+---
+import { Icon } from "astro-icon/components";
+---
+
 <theme-toggle class="flex flex-col">
   <button
-    class="text-accent-2 hover:text-accent focus-visible:outline-accent flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center text-base leading-none transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
+    class="text-accent-2 hover:text-accent focus-visible:outline-accent flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
     type="button"
   >
     <span class="sr-only">Toggle theme</span>
-    <span aria-hidden="true" class="dark:hidden">☾</span>
-    <span aria-hidden="true" class="hidden dark:inline">☀</span>
+    <Icon aria-hidden="true" class="h-5 w-5" focusable="false" name="line-md:light-dark" />
   </button>
 </theme-toggle>
 

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,17 +1,45 @@
 ---
+import { Icon } from "astro-icon/components";
 import { siteConfig } from "@/site.config";
-
-const year = new Date().getFullYear();
 ---
 
 <footer class="flex min-h-15 flex-col">
   <div class="page-shell py-10 text-gray-600 sm:flex-col dark:text-gray-400">
-    <div class="me-0 sm:me-4">
-      &copy; {siteConfig.author}
-      {year}. The source code is available on <a
-        href="https://github.com/xdanger/xdanger-com"
-        class="border-b">GitHub</a
-      >.
+    <div class="grid items-center gap-x-4 gap-y-2 sm:grid-cols-[1fr_auto_1fr]">
+      <a
+        href="https://github.com/xdanger/xdanger.com"
+        class="hover:text-accent focus-visible:ring-accent inline-flex items-center gap-2 justify-self-start rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        aria-label="GitHub repository"
+      >
+        <Icon aria-hidden="true" class="h-5 w-5" focusable="false" name="mdi:github" />
+        <span>{siteConfig.author}</span>
+      </a>
+      <a
+        href="https://creativecommons.org/licenses/by-sa/4.0/"
+        class="hover:text-accent focus-visible:ring-accent inline-flex items-center gap-1 rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none max-sm:justify-self-center"
+        aria-label="Creative Commons Attribution-ShareAlike 4.0 International"
+      >
+        <Icon
+          aria-hidden="true"
+          class="h-5 w-5"
+          focusable="false"
+          name="fa6-brands:creative-commons"
+        />
+        <Icon
+          aria-hidden="true"
+          class="h-5 w-5"
+          focusable="false"
+          name="fa6-brands:creative-commons-by"
+        />
+        <Icon
+          aria-hidden="true"
+          class="h-5 w-5"
+          focusable="false"
+          name="fa6-brands:creative-commons-sa"
+        />
+        <span>CC BY-SA 4.0</span>
+      </a>
+      <span aria-hidden="true"></span>
     </div>
   </div>
 </footer>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -9,7 +9,7 @@ import { siteConfig } from "@/site.config";
       <a
         href="https://github.com/xdanger/xdanger.com"
         class="hover:text-accent focus-visible:ring-accent inline-flex items-center gap-2 justify-self-start rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-        aria-label="GitHub repository"
+        aria-label={`${siteConfig.author} on GitHub`}
       >
         <Icon aria-hidden="true" class="h-5 w-5" focusable="false" name="mdi:github" />
         <span>{siteConfig.author}</span>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -17,7 +17,7 @@ import { siteConfig } from "@/site.config";
       <a
         href="https://creativecommons.org/licenses/by-sa/4.0/"
         class="hover:text-accent focus-visible:ring-accent inline-flex items-center gap-1 rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none max-sm:justify-self-center"
-        aria-label="Creative Commons Attribution-ShareAlike 4.0 International"
+        aria-label="CC BY-SA 4.0 Creative Commons Attribution-ShareAlike 4.0 International"
       >
         <Icon
           aria-hidden="true"

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -6,18 +6,19 @@ import { siteConfig } from "@/site.config";
 <header
   data-collapsed="false"
   id="site-header"
-  class="pointer-events-none sticky top-0 z-50 h-[4.25rem] w-full sm:h-[5.25rem]"
+  style="--header-collapse-offset: 0px; --header-padding-y: 3rem; --header-padding-y-sm: 4.5rem; --header-padding-y-md: 6rem; --header-tagline-max-height: 2rem; --header-tagline-margin-top: 0.25rem; --header-tagline-opacity: 1;"
+  class="pointer-events-none sticky top-0 z-50 w-full"
 >
   <div
     class="bg-background/95 supports-[backdrop-filter]:bg-background/60 [[data-collapsed=true]_&]:border-foreground/10 pointer-events-auto w-full border-b-0 border-dotted border-transparent backdrop-blur-sm transition-colors [[data-collapsed=true]_&]:border-b"
   >
-    <div class="page-shell relative z-10 flex items-start justify-between gap-4 py-3 sm:py-4">
+    <div class="site-header-shell page-shell relative z-10 flex items-start justify-between gap-4">
       <div>
-        <p class="text-accent-2 font-plex-serif text-xl leading-none font-semibold sm:text-2xl">
+        <p class="text-accent-2 font-plex-serif text-lg leading-none font-semibold sm:text-xl">
           <a href="/" data-astro-prefetch>{siteConfig.author}</a>
         </p>
         <p
-          class="font-plex-mono mt-1 max-h-8 max-w-2xl overflow-hidden text-xs leading-relaxed text-gray-600 transition-[max-height,opacity,margin-top] duration-200 ease-out sm:text-sm dark:text-gray-400 [[data-collapsed=true]_&]:mt-0 [[data-collapsed=true]_&]:max-h-0 [[data-collapsed=true]_&]:opacity-0"
+          class="site-header-tagline font-plex-mono max-w-2xl overflow-hidden text-xs leading-relaxed text-gray-600 sm:text-sm dark:text-gray-400"
         >
           Notes on tech, products, and life.
         </p>
@@ -27,19 +28,101 @@ import { siteConfig } from "@/site.config";
   </div>
 </header>
 
+<style>
+  #site-header {
+    --header-collapse-offset: 0px;
+    --header-padding-y: 3rem;
+    --header-padding-y-sm: 4.5rem;
+    --header-padding-y-md: 6rem;
+    --header-tagline-margin-top: 0.25rem;
+    --header-tagline-max-height: 2rem;
+    --header-tagline-opacity: 1;
+
+    margin-bottom: var(--header-collapse-offset);
+  }
+
+  .site-header-shell {
+    padding-block: var(--header-padding-y);
+  }
+
+  .site-header-tagline {
+    margin-top: var(--header-tagline-margin-top);
+    max-height: var(--header-tagline-max-height);
+    opacity: var(--header-tagline-opacity);
+  }
+
+  @media (min-width: 640px) {
+    .site-header-shell {
+      padding-block: var(--header-padding-y-sm);
+    }
+  }
+
+  @media (min-width: 768px) {
+    .site-header-shell {
+      padding-block: var(--header-padding-y-md);
+    }
+  }
+</style>
+
 <script>
-  let headerCollapsed = false;
+  const COMPACT_PADDING_Y = 12;
+  const COMPACT_PADDING_Y_SM = 16;
+  const COMPACT_PADDING_Y_MD = 16;
+  const EXPANDED_PADDING_Y = 48;
+  const EXPANDED_PADDING_Y_SM = 72;
+  const EXPANDED_PADDING_Y_MD = 96;
+  const TAGLINE_MARGIN_TOP = 4;
+  const TAGLINE_MAX_HEIGHT = 32;
+
+  let compactScrollY = 192;
   let ticking = false;
+
+  function setHeaderExpandedness(siteHeader: HTMLElement, expandedness: number) {
+    const paddingY = COMPACT_PADDING_Y + (EXPANDED_PADDING_Y - COMPACT_PADDING_Y) * expandedness;
+    const paddingYSm =
+      COMPACT_PADDING_Y_SM + (EXPANDED_PADDING_Y_SM - COMPACT_PADDING_Y_SM) * expandedness;
+    const paddingYMd =
+      COMPACT_PADDING_Y_MD + (EXPANDED_PADDING_Y_MD - COMPACT_PADDING_Y_MD) * expandedness;
+
+    siteHeader.style.setProperty("--header-padding-y", `${paddingY}px`);
+    siteHeader.style.setProperty("--header-padding-y-sm", `${paddingYSm}px`);
+    siteHeader.style.setProperty("--header-padding-y-md", `${paddingYMd}px`);
+    siteHeader.style.setProperty(
+      "--header-tagline-margin-top",
+      `${TAGLINE_MARGIN_TOP * expandedness}px`,
+    );
+    siteHeader.style.setProperty(
+      "--header-tagline-max-height",
+      `${TAGLINE_MAX_HEIGHT * expandedness}px`,
+    );
+    siteHeader.style.setProperty("--header-tagline-opacity", String(expandedness));
+  }
+
+  function measureHeaderCollapseDistance() {
+    const siteHeader = document.getElementById("site-header") as HTMLElement | null;
+    if (!siteHeader) return;
+
+    siteHeader.style.setProperty("--header-collapse-offset", "0px");
+    setHeaderExpandedness(siteHeader, 1);
+    const expandedHeight = siteHeader.getBoundingClientRect().height;
+
+    setHeaderExpandedness(siteHeader, 0);
+    const compactHeight = siteHeader.getBoundingClientRect().height;
+
+    compactScrollY = Math.max(expandedHeight - compactHeight, 1);
+    updateHeaderCollapse();
+  }
 
   function updateHeaderCollapse() {
     const siteHeader = document.getElementById("site-header") as HTMLElement | null;
     if (!siteHeader) return;
 
-    const shouldCollapse = headerCollapsed ? window.scrollY > 8 : window.scrollY > 48;
-    if (shouldCollapse === headerCollapsed) return;
+    const progress = Math.min(Math.max(window.scrollY / compactScrollY, 0), 1);
+    const expandedness = 1 - progress;
 
-    headerCollapsed = shouldCollapse;
-    siteHeader.setAttribute("data-collapsed", String(headerCollapsed));
+    setHeaderExpandedness(siteHeader, expandedness);
+    siteHeader.style.setProperty("--header-collapse-offset", `${compactScrollY * progress}px`);
+    siteHeader.setAttribute("data-collapsed", String(progress === 1));
   }
 
   function scheduleHeaderCollapseUpdate() {
@@ -52,10 +135,10 @@ import { siteConfig } from "@/site.config";
     });
   }
 
-  updateHeaderCollapse();
+  measureHeaderCollapseDistance();
   document.addEventListener("scroll", scheduleHeaderCollapseUpdate, { passive: true });
+  window.addEventListener("resize", measureHeaderCollapseDistance);
   document.addEventListener("astro:after-swap", () => {
-    headerCollapsed = false;
-    updateHeaderCollapse();
+    measureHeaderCollapseDistance();
   });
 </script>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -6,7 +6,7 @@ import { siteConfig } from "@/site.config";
 <header
   data-collapsed="false"
   id="site-header"
-  style="--header-collapse-offset: 0px; --header-padding-y: 3rem; --header-padding-y-sm: 4.5rem; --header-padding-y-md: 6rem; --header-tagline-max-height: 2rem; --header-tagline-margin-top: 0.25rem; --header-tagline-opacity: 1;"
+  style="--header-collapse-offset: 0px;"
   class="pointer-events-none sticky top-0 z-50 w-full"
 >
   <div
@@ -76,6 +76,7 @@ import { siteConfig } from "@/site.config";
 
   let compactScrollY = 192;
   let ticking = false;
+  let measureTicking = false;
 
   function setHeaderExpandedness(siteHeader: HTMLElement, expandedness: number) {
     const paddingY = COMPACT_PADDING_Y + (EXPANDED_PADDING_Y - COMPACT_PADDING_Y) * expandedness;
@@ -135,10 +136,27 @@ import { siteConfig } from "@/site.config";
     });
   }
 
-  measureHeaderCollapseDistance();
-  document.addEventListener("scroll", scheduleHeaderCollapseUpdate, { passive: true });
-  window.addEventListener("resize", measureHeaderCollapseDistance);
-  document.addEventListener("astro:after-swap", () => {
+  function scheduleHeaderCollapseMeasure() {
+    if (measureTicking) return;
+
+    measureTicking = true;
+    window.requestAnimationFrame(() => {
+      measureHeaderCollapseDistance();
+      measureTicking = false;
+    });
+  }
+
+  function measureHeaderCollapseDistanceWithFonts() {
     measureHeaderCollapseDistance();
+    if (document.fonts?.ready) {
+      void document.fonts.ready.then(scheduleHeaderCollapseMeasure);
+    }
+  }
+
+  measureHeaderCollapseDistanceWithFonts();
+  document.addEventListener("scroll", scheduleHeaderCollapseUpdate, { passive: true });
+  window.addEventListener("resize", scheduleHeaderCollapseMeasure);
+  document.addEventListener("astro:after-swap", () => {
+    measureHeaderCollapseDistanceWithFonts();
   });
 </script>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -22,7 +22,7 @@ const {
       post={post}
     />
   </head>
-  <body class="bg-background overscroll-none antialiased dark:scrollbar-thumb-gray-700">
+  <body class="bg-background antialiased dark:scrollbar-thumb-gray-700">
     <div
       class="text-foreground text-offgray dark:text-offgray-300 flex min-h-svh min-w-svw flex-col text-sm"
     >

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,7 +3,7 @@ import AboutMe from "@/components/AboutMe.astro";
 import PageLayout from "@/layouts/Base.astro";
 
 const meta = {
-  description: "About Yunjie Dai",
+  description: "About Kros Dai",
   title: "About",
 };
 ---

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -20,7 +20,7 @@ export const siteConfig: SiteConfig = {
   // Meta property, found in src/components/BaseHead.astro L:42
   ogLocale: "en_US",
   // Used to construct the meta title property found in src/components/BaseHead.astro L:11, and webmanifest name found in astro.config.ts L:42
-  title: "Yunjie Dai",
+  title: "Kros Dai",
   // ! Please remember to replace the following site property with your own domain, used in astro.config.ts
   url: "https://www.xdanger.com/",
 };

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -3,7 +3,7 @@ import type { AstroExpressiveCodeOptions } from "astro-expressive-code";
 
 export const siteConfig: SiteConfig = {
   // Used as both a meta property (src/components/BaseHead.astro L:31 + L:49) & the generated satori png (src/pages/og-image/[slug].png.ts)
-  author: "Yunjie Dai",
+  author: "Kros Dai",
   // Date.prototype.toLocaleDateString() parameters, found in src/utils/date.ts.
   date: {
     locale: "en-US",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -299,7 +299,6 @@
     color-scheme: light dark;
     accent-color: var(--color-accent);
     min-height: 100%;
-    overscroll-behavior: none;
 
     &[data-theme="light"] {
       color-scheme: light;
@@ -321,7 +320,6 @@
     @apply font-plex-sans;
     min-height: 100%;
     background-color: var(--color-background);
-    overscroll-behavior: none;
   }
   :where(h1, h2, h3, h4, h5, h6) {
     font-family: var(--font-alias-plexSerif);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,11 +7,11 @@
 @variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 @font-face {
-  font-family: "Newsreader Variable";
+  font-family: "Crimson Pro Variable";
   font-style: normal;
   font-display: swap;
-  font-weight: 200 800;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/newsreader:vf@latest/latin-wght-normal.woff2")
+  font-weight: 200 900;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/crimson-pro:vf@latest/latin-wght-normal.woff2")
     format("woff2-variations");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
@@ -19,11 +19,11 @@
 }
 
 @font-face {
-  font-family: "Newsreader Variable";
+  font-family: "Crimson Pro Variable";
   font-style: normal;
   font-display: swap;
-  font-weight: 200 800;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/newsreader:vf@latest/latin-ext-wght-normal.woff2")
+  font-weight: 200 900;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/crimson-pro:vf@latest/latin-ext-wght-normal.woff2")
     format("woff2-variations");
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
     U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
@@ -31,11 +31,11 @@
 }
 
 @font-face {
-  font-family: "Newsreader Variable";
+  font-family: "Crimson Pro Variable";
   font-style: italic;
   font-display: swap;
-  font-weight: 200 800;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/newsreader:vf@latest/latin-wght-italic.woff2")
+  font-weight: 200 900;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/crimson-pro:vf@latest/latin-wght-italic.woff2")
     format("woff2-variations");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
@@ -43,11 +43,11 @@
 }
 
 @font-face {
-  font-family: "Newsreader Variable";
+  font-family: "Crimson Pro Variable";
   font-style: italic;
   font-display: swap;
-  font-weight: 200 800;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/newsreader:vf@latest/latin-ext-wght-italic.woff2")
+  font-weight: 200 900;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/crimson-pro:vf@latest/latin-ext-wght-italic.woff2")
     format("woff2-variations");
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
     U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
@@ -279,7 +279,7 @@
   --color-accent-2: oklch(18.15% 0 0);
   --color-quote: oklch(55.27% 0.195 19.06);
   /* --color-quote: var(--muted-foreground); */
-  --font-alias-plexSerif: "Newsreader Variable", "LXGW WenKai", "LXGW WenKai Lite",
+  --font-alias-plexSerif: "Crimson Pro Variable", "LXGW WenKai", "LXGW WenKai Lite",
     ui-serif, Georgia, "Times New Roman", serif;
   --font-alias-plexSans: "iA Writer Quattro", ui-sans-serif, system-ui, sans-serif;
   --font-alias-writer: "Inter Variable", "LXGW WenKai Lite", ui-sans-serif, system-ui,


### PR DESCRIPTION
## Summary

- refine the sticky header collapse model with responsive expanded spacing
- update visible site identity to Kros Dai and switch the serif face to Crimson Pro
- add the CC BY-SA 4.0 license and center license attribution in the footer

## Validation

- pnpm lint
- pnpm build:site

## Notes

`pnpm build:site` still emits the existing Astro markdown plugin deprecation notice, missing webmention token notice, and webmanifest icon warning; the build completed successfully.