### PR TITLE
[codex] refine theme and app icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@eslint/js": "^10.0.1",
+    "@iconify-json/circum": "^1.2.2",
     "@iconify-json/fa6-brands": "^1.2.6",
-    "@iconify-json/line-md": "^1.2.16",
     "@iconify-json/material-symbols-light": "^1.2.75",
     "@iconify-json/mdi": "^1.2.3",
     "@iconify-json/solar": "^1.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,12 +102,12 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
+      '@iconify-json/circum':
+        specifier: ^1.2.2
+        version: 1.2.2
       '@iconify-json/fa6-brands':
         specifier: ^1.2.6
         version: 1.2.6
-      '@iconify-json/line-md':
-        specifier: ^1.2.16
-        version: 1.2.16
       '@iconify-json/material-symbols-light':
         specifier: ^1.2.75
         version: 1.2.75
@@ -547,11 +547,11 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iconify-json/circum@1.2.2':
+    resolution: {integrity: sha512-lIC4xg4p62SValfSiUnrcuLKYf2rpgDydlGu9V3PwO7rVfNB4P1gMgt/Hqs7M0ttDEBC6hSxxMlXDfQGNXmVqA==}
+
   '@iconify-json/fa6-brands@1.2.6':
     resolution: {integrity: sha512-twL3X4KWcxAhbc1vz/mIDsVr+CAItk1/EIfxKUVQtpv6O4eydk5KNYqTZWdvJNHGInUgd6vKg21aWfVgb5DXEg==}
-
-  '@iconify-json/line-md@1.2.16':
-    resolution: {integrity: sha512-esHPUQUp30NyqJWa7MNu6ExdG8z/aEFC5r56rVyRGhtJ7acOme6YtYPnDOgVu6p+kk24rM8602xkFuBC6g6x+w==}
 
   '@iconify-json/material-symbols-light@1.2.75':
     resolution: {integrity: sha512-YapyS2x6BoADGR3OUjmRavrwjE5VyVLyky1cyokGA4el0Km5RSJsfvvrnTsK5bomZZGFCP0bBH6hokk2Z6FeHg==}
@@ -4385,11 +4385,11 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@iconify-json/fa6-brands@1.2.6':
+  '@iconify-json/circum@1.2.2':
     dependencies:
       '@iconify/types': 2.0.0
 
-  '@iconify-json/line-md@1.2.16':
+  '@iconify-json/fa6-brands@1.2.6':
     dependencies:
       '@iconify/types': 2.0.0
 

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -5,9 +5,11 @@
   aria-labelledby="title desc"
 >
   <title id="title">Daihaus d mark</title>
-  <desc id="desc">A red lowercase d mark built from a circle and a vertical bar.</desc>
+  <desc id="desc">A white lowercase d mark on a rounded red background.</desc>
 
-  <g fill="#b02e22" shape-rendering="geometricPrecision">
+  <rect width="512" height="512" rx="112" fill="#b02e22" />
+
+  <g fill="#fff" shape-rendering="geometricPrecision">
     <circle cx="240.8" cy="343.9" r="112.1" />
     <rect x="337.8" y="56" width="45.4" height="397.7" />
   </g>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -8,7 +8,18 @@ import { Icon } from "astro-icon/components";
     type="button"
   >
     <span class="sr-only">Toggle theme</span>
-    <Icon aria-hidden="true" class="h-5 w-5" focusable="false" name="line-md:light-dark" />
+    <Icon
+      aria-hidden="true"
+      class="block h-5 w-5 dark:hidden"
+      focusable="false"
+      name="solar:sun-outline"
+    />
+    <Icon
+      aria-hidden="true"
+      class="hidden h-5 w-5 dark:block"
+      focusable="false"
+      name="circum:dark"
+    />
   </button>
 </theme-toggle>
 
@@ -23,13 +34,6 @@ import { Icon } from "astro-icon/components";
       const button = this.querySelector<HTMLButtonElement>("button");
 
       if (button) {
-        const replayIcon = () => {
-          const icon = button.querySelector("svg");
-          if (!icon) return;
-
-          icon.replaceWith(icon.cloneNode(true));
-        };
-
         const setLabel = () => {
           button.setAttribute(
             "aria-label",
@@ -51,7 +55,6 @@ import { Icon } from "astro-icon/components";
             },
           });
           document.dispatchEvent(themeChangeEvent);
-          replayIcon();
         });
       } else {
         console.warn("Theme Toggle: No button found");


### PR DESCRIPTION
## Summary

- Replace the animated theme toggle icon with static light and dark icons.
- Swap the unused `line-md` iconset for `circum` and keep `solar` for the sun icon.
- Update `public/icon.svg` to use a rounded red background with a white mark and transparent corners.

## Validation

- `pnpm lint`
- Verified the theme toggle and SVG icon in the local browser preview.