### PR TITLE
🔧 chore(config): adopt markdown unified processor

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "astro-dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 4321
+    },
+    {
+      "name": "astro-preview",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["preview"],
+      "port": 4321
+    }
+  ]
+}

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -10,7 +10,7 @@
     {
       "name": "astro-preview",
       "runtimeExecutable": "sh",
-      "runtimeArgs": ["-c", "pnpm build:site && pnpm preview --port 4322"],
+      "runtimeArgs": ["-c", "pnpm build && pnpm preview --port 4322"],
       "port": 4322
     }
   ]

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -9,9 +9,9 @@
     },
     {
       "name": "astro-preview",
-      "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["preview"],
-      "port": 4321
+      "runtimeExecutable": "sh",
+      "runtimeArgs": ["-c", "pnpm build:site && pnpm preview --port 4322"],
+      "port": 4322
     }
   ]
 }

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -17,7 +17,7 @@ import { remarkAdmonitions } from "./src/plugins/remark-admonitions"; /* Add adm
 import { remarkReadingTime } from "./src/plugins/remark-reading-time"; /* Add reading time */
 
 // Rehype plugins
-import { rehypeHeadingIds } from "@astrojs/markdown-remark";
+import { rehypeHeadingIds, unified } from "@astrojs/markdown-remark";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeExternalLinks from "rehype-external-links";
 import rehypeKatex from "rehype-katex";
@@ -78,25 +78,36 @@ export default defineConfig({
     }),
   ],
   markdown: {
-    rehypePlugins: [
-      rehypeHeadingIds,
-      [rehypeAutolinkHeadings, { behavior: "wrap", properties: { className: ["not-prose"] } }],
-      [
-        rehypeExternalLinks,
-        {
-          rel: ["noreferrer", "noopener"],
-          target: "_blank",
-        },
+    // Astro 6 deprecated the top-level `remarkPlugins`/`rehypePlugins`/`remarkRehype`
+    // options. They now live on a `unified({...})` processor from
+    // `@astrojs/markdown-remark`. Defaults (gfm, smartypants, syntax highlighting)
+    // stay enabled because they're baked into `unified()` itself.
+    //
+    // NOTE: the `[astro] markdown.*Plugins are deprecated` warning still prints at
+    // startup — it comes from astro-expressive-code (≤0.42.0), which injects its
+    // rehype plugin via the legacy `markdown.rehypePlugins` channel. It's harmless
+    // and will clear once that package migrates to `markdown.processor` upstream.
+    processor: unified({
+      rehypePlugins: [
+        rehypeHeadingIds,
+        [rehypeAutolinkHeadings, { behavior: "wrap", properties: { className: ["not-prose"] } }],
+        [
+          rehypeExternalLinks,
+          {
+            rel: ["noreferrer", "noopener"],
+            target: "_blank",
+          },
+        ],
+        [rehypeKatex, { strict: true }],
+        rehypeUnwrapImages,
       ],
-      [rehypeKatex, { strict: true }],
-      rehypeUnwrapImages,
-    ],
-    remarkPlugins: [remarkReadingTime, remarkDirective, remarkAdmonitions, remarkMath],
-    remarkRehype: {
-      footnoteLabelProperties: {
-        className: [""],
+      remarkPlugins: [remarkReadingTime, remarkDirective, remarkAdmonitions, remarkMath],
+      remarkRehype: {
+        footnoteLabelProperties: {
+          className: [""],
+        },
       },
-    },
+    }),
   },
   output: "static",
   // https://docs.astro.build/en/guides/prefetch/


### PR DESCRIPTION
## What

- **`astro.config.ts`** — migrate the Markdown plugin configuration from the deprecated top-level `markdown.remarkPlugins` / `markdown.rehypePlugins` / `markdown.remarkRehype` options to the new `markdown.processor: unified({ ... })` API from `@astrojs/markdown-remark`.
- **`.claude/launch.json`** — add a preview launch config declaring the `astro dev` / `astro preview` servers (consistent with the already-tracked `.claude/` tooling).

## Why

Astro 6 deprecated those top-level fields (they "will be removed in a future major"). Registering our own remark/rehype plugins on a `unified()` processor is the recommended migration and keeps this config valid past their removal.

Behavior is unchanged — `unified()` keeps GFM, smart punctuation, and syntax highlighting on by default, and MDX inherits the plugins from `processor.options`. Verified locally: home and post pages return `200` with expressive-code blocks, KaTeX math, and heading anchors all intact. `prettier`, `eslint`, and `astro check` all pass.

## Note for reviewers

A `[astro] markdown.*Plugins are deprecated` warning still prints once at dev startup. It is **not** from this config — `astro-expressive-code` (≤ 0.42.0, the current latest release) still registers its rehype plugin through the legacy `markdown.rehypePlugins` channel, which is what trips Astro's compat shim. There is no upstream release to upgrade to yet; the warning is harmless (one-time, at startup) and will clear once that package migrates to `markdown.processor`. This is documented in a comment in `astro.config.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
