### PR TITLE
[codex] restyle homepage article list

### DIFF
--- a/src/components/blog/HomePostPreview.astro
+++ b/src/components/blog/HomePostPreview.astro
@@ -1,0 +1,44 @@
+---
+import type { CollectionEntry } from "astro:content";
+import FormattedDate from "@/components/FormattedDate.astro";
+import { getPostPath } from "@/utils/url";
+import type { HTMLTag, Polymorphic } from "astro/types";
+
+type Props<Tag extends HTMLTag> = Polymorphic<{ as: Tag }> & {
+  post: CollectionEntry<"post">;
+};
+
+const { as: Tag = "h3", post } = Astro.props;
+const postUrl = getPostPath(post);
+const subtitle = post.data.subtitle?.trim();
+---
+
+<a
+  class="group -mx-3 block cursor-pointer px-3 transition-colors hover:bg-gray-200/10"
+  data-astro-prefetch
+  href={postUrl}
+>
+  <article class="grid gap-3 py-5 sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-8 sm:py-6">
+    <FormattedDate
+      class="pt-1 text-xs text-gray-600 uppercase sm:text-right dark:text-gray-400"
+      date={post.data.publishDate}
+      dateTimeOptions={{ day: "numeric" }}
+    />
+    <div>
+      <Tag class="font-plex-serif text-lg leading-tight text-pretty sm:text-xl">
+        {post.data.draft && <span class="text-red-500">(Draft) </span>}
+        <span class="text-accent-2 group-hover:text-accent transition-colors">
+          <span class="sr-only">Read </span>
+          {post.data.title}
+        </span>
+      </Tag>
+      {
+        subtitle && (
+          <p class="font-plex-sans mt-2 max-w-2xl text-sm leading-snug text-gray-600 dark:text-gray-400">
+            {subtitle}
+          </p>
+        )
+      }
+    </div>
+  </article>
+</a>

--- a/src/components/blog/HomePostPreview.astro
+++ b/src/components/blog/HomePostPreview.astro
@@ -14,7 +14,7 @@ const subtitle = post.data.subtitle?.trim();
 ---
 
 <a
-  class="group -mx-3 block cursor-pointer px-3 transition-colors hover:bg-gray-200/10"
+  class="focus-visible:outline-accent group -mx-3 block cursor-pointer px-3 transition-colors hover:bg-gray-200/10 focus-visible:bg-gray-200/10 focus-visible:outline-2 focus-visible:outline-offset-2"
   data-astro-prefetch
   href={postUrl}
 >
@@ -27,7 +27,9 @@ const subtitle = post.data.subtitle?.trim();
     <div>
       <Tag class="font-plex-serif text-lg leading-tight text-pretty sm:text-xl">
         {post.data.draft && <span class="text-red-500">(Draft) </span>}
-        <span class="text-accent-2 group-hover:text-accent transition-colors">
+        <span
+          class="text-accent-2 group-hover:text-accent group-focus-visible:text-accent transition-colors"
+        >
           <span class="sr-only">Read </span>
           {post.data.title}
         </span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import { type CollectionEntry, getCollection } from "astro:content";
 import AboutMe from "@/components/AboutMe.astro";
-import PostPreview from "@/components/blog/PostPreview.astro";
+import HomePostPreview from "@/components/blog/HomePostPreview.astro";
 import Note from "@/components/note/Note.astro";
 import { getAllPosts } from "@/data/post";
 import PageLayout from "@/layouts/Base.astro";
@@ -30,13 +30,13 @@ const latestNotes = allNotes.sort(collectionDateSort).slice(0, MAX_NOTES);
     </div>
   </section>
   <section class="py-5 sm:py-6">
-    <div class="page-shell grid gap-6 md:grid-cols-[1fr_3fr]">
+    <div class="page-shell grid gap-6 md:grid-cols-[9rem_minmax(0,1fr)]">
       <h2 class="section-heading"><a href="/posts">blog</a></h2>
-      <ul class="space-y-4" role="list">
+      <ul class="border-foreground/5 border-b dark:border-white/5" role="list">
         {
           allPostsByDate.map((p) => (
-            <li class="grid gap-2 sm:grid-cols-[auto_1fr]">
-              <PostPreview post={p} />
+            <li class="border-foreground/5 border-t dark:border-white/5">
+              <HomePostPreview as="h3" post={p} />
             </li>
           ))
         }


### PR DESCRIPTION
## Summary

- add a homepage-specific post preview component for the Chronicle-style article list
- align the blog list with the page shell, solid subtle dividers, and whole-row hover/click behavior
- render homepage subtitles from `subtitle` only, without falling back to `description`

## Validation

- pnpm exec prettier --write src/components/blog/PostPreview.astro src/components/blog/HomePostPreview.astro src/pages/index.astro
- pnpm exec eslint --fix src/components/blog/PostPreview.astro src/components/blog/HomePostPreview.astro src/pages/index.astro
- pnpm exec autocorrect --fix src/components/blog/PostPreview.astro src/components/blog/HomePostPreview.astro src/pages/index.astro
- pnpm run build:site
- verified homepage DOM/styles in the in-app browser at http://127.0.0.1:4325/
