### PR TITLE
[codex] update site typography

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -89,7 +89,11 @@ const socialImageURL = new URL(ogImage ? ogImage : "/social-card.png", Astro.url
 />
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/gh/tingjieguo/lxgw-bright-webfont@ab75969243cc9c0af39aabfc6e88f48887f9db10/style.css"
+  href="https://cdn.jsdelivr.net/gh/tingjieguo/lxgw-bright-webfont@ab75969243cc9c0af39aabfc6e88f48887f9db10/build/LXGWBright-Regular/result.css"
+/>
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/gh/tingjieguo/lxgw-bright-webfont@ab75969243cc9c0af39aabfc6e88f48887f9db10/build/LXGWBright-Medium/result.css"
 />
 
 {/* KaTeX */}

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -85,10 +85,6 @@ const socialImageURL = new URL(ogImage ? ogImage : "/social-card.png", Astro.url
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/lxgw-wenkai-lite-webfont@1.1.0/style.css"
-/>
-<link
-  rel="stylesheet"
   href="https://cdn.jsdelivr.net/gh/tingjieguo/lxgw-bright-webfont@ab75969243cc9c0af39aabfc6e88f48887f9db10/build/LXGWBright-Regular/result.css"
 />
 <link

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -87,6 +87,10 @@ const socialImageURL = new URL(ogImage ? ogImage : "/social-card.png", Astro.url
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/lxgw-wenkai-lite-webfont@1.1.0/style.css"
 />
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/gh/tingjieguo/lxgw-bright-webfont@ab75969243cc9c0af39aabfc6e88f48887f9db10/style.css"
+/>
 
 {/* KaTeX */}
 <script

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -91,6 +91,14 @@ const socialImageURL = new URL(ogImage ? ogImage : "/social-card.png", Astro.url
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/gh/tingjieguo/lxgw-bright-webfont@ab75969243cc9c0af39aabfc6e88f48887f9db10/build/LXGWBright-Medium/result.css"
 />
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/gh/tingjieguo/lxgw-bright-webfont@ab75969243cc9c0af39aabfc6e88f48887f9db10/build/LXGWBright-Italic/result.css"
+/>
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/gh/tingjieguo/lxgw-bright-webfont@ab75969243cc9c0af39aabfc6e88f48887f9db10/build/LXGWBright-MediumItalic/result.css"
+/>
 
 {/* KaTeX */}
 <script

--- a/src/components/blog/Masthead.astro
+++ b/src/components/blog/Masthead.astro
@@ -36,7 +36,7 @@ const dateTimeOptions: Intl.DateTimeFormatOptions = {
 </h1>
 {subtitle && <p class="subtitle">{subtitle}</p>}
 <div
-  class="font-plex-serif flex flex-wrap items-center gap-x-3 gap-y-2 text-base text-gray-700 italic dark:text-gray-300"
+  class="font-plex-serif flex flex-wrap items-center gap-x-3 gap-y-2 text-base text-gray-700 dark:text-gray-300"
 >
   <p>
     <FormattedDate date={data.publishDate} dateTimeOptions={dateTimeOptions} />

--- a/src/components/blog/PostPreview.astro
+++ b/src/components/blog/PostPreview.astro
@@ -20,4 +20,4 @@ const postUrl = getPostPath(post);
     {post.data.title}
   </a>
 </Tag>
-{withDesc && <q class="line-clamp-3 italic">{post.data.description}</q>}
+{withDesc && <q class="line-clamp-3">{post.data.description}</q>}

--- a/src/components/blog/webmentions/Comments.astro
+++ b/src/components/blog/webmentions/Comments.astro
@@ -55,7 +55,7 @@ const comments = mentions.filter(
             ) : null}
             <div class="flex-auto">
               <div class="p-author h-card flex items-center justify-between gap-x-2">
-                <p class="p-name text-accent-2 my-0 line-clamp-1 font-semibold">
+                <p class="p-name text-accent-2 font-plex-serif-medium my-0 line-clamp-1 font-medium">
                   {mention.author?.name}
                 </p>
                 {safeHref(mention.url) && (

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -13,7 +13,9 @@ import { siteConfig } from "@/site.config";
   >
     <div class="site-header-shell page-shell relative z-10 flex items-start justify-between gap-4">
       <div>
-        <p class="text-accent-2 font-plex-serif text-xl leading-none font-medium sm:text-2xl">
+        <p
+          class="text-accent-2 font-plex-serif-medium text-xl leading-none font-medium sm:text-2xl"
+        >
           <a href="/" data-astro-prefetch>{siteConfig.author}</a>
         </p>
         <p

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -13,7 +13,7 @@ import { siteConfig } from "@/site.config";
   >
     <div class="site-header-shell page-shell relative z-10 flex items-start justify-between gap-4">
       <div>
-        <p class="text-accent-2 font-plex-serif text-xl leading-none font-semibold sm:text-2xl">
+        <p class="text-accent-2 font-plex-serif text-xl leading-none font-medium sm:text-2xl">
           <a href="/" data-astro-prefetch>{siteConfig.author}</a>
         </p>
         <p

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -23,7 +23,7 @@ const articleDate = updatedDate?.toISOString() ?? publishDate.toISOString();
   <article class="flex-colgrow flex break-words" data-pagefind-body>
     <div class="content-shell flex-col gap-10 py-4 sm:py-6 lg:flex-row lg:items-start">
       <div
-        class="prose prose-lg prose-headings:font-semibold prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none max-w-3xl"
+        class="prose prose-lg prose-headings:font-medium prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none max-w-3xl"
       >
         <slot />
         <WebMentions />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -23,7 +23,7 @@ const articleDate = updatedDate?.toISOString() ?? publishDate.toISOString();
   <article class="flex-colgrow flex break-words" data-pagefind-body>
     <div class="content-shell flex-col gap-10 py-4 sm:py-6 lg:flex-row lg:items-start">
       <div
-        class="prose prose-lg prose-headings:font-medium prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none max-w-3xl"
+        class="prose prose-lg prose-headings:font-plex-serif-medium prose-headings:font-medium prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none max-w-3xl"
       >
         <slot />
         <WebMentions />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -130,7 +130,7 @@
 /* Shadcn UI theme https://ui.shadcn.com/themes */
 :root {
   --radius: 0.5rem;
-  --background: oklch(97.86% 0.006 96);
+  --background: oklch(98.5% 0.006 96);
   --foreground: oklch(0.141 0.005 285.823); /* oklch(26.99% 0.0096 235.05) */
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.141 0.005 285.823);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -159,12 +159,14 @@
   --color-accent-2: oklch(18.15% 0 0);
   --color-quote: oklch(55.27% 0.195 19.06);
   /* --color-quote: var(--muted-foreground); */
-  --font-alias-plexSerif: "LXGW Bright Medium", "LXGW Bright", ui-serif, serif;
+  --font-alias-plexSerif: "LXGW Bright", "LXGW Bright Medium", ui-serif, serif;
+  --font-alias-plexSerifMedium: "LXGW Bright Medium", "LXGW Bright", ui-serif, serif;
   --font-alias-plexSans: "iA Writer Quattro", ui-sans-serif, system-ui, sans-serif;
   --font-alias-writer: "LXGW Bright", ui-sans-serif, system-ui, sans-serif;
   --font-alias-plexMono: "iA Writer Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
     Consolas, "Liberation Mono", "Courier New", monospace;
   --font-plex-serif: var(--font-alias-plexSerif);
+  --font-plex-serif-medium: var(--font-alias-plexSerifMedium);
   --font-plex-sans: var(--font-alias-plexSans);
   --font-writer: var(--font-alias-writer);
   --font-plex-mono: var(--font-alias-plexMono);
@@ -200,7 +202,7 @@
     background-color: var(--color-background);
   }
   :where(h1, h2, h3, h4, h5, h6) {
-    font-family: var(--font-alias-plexSerif);
+    font-family: var(--font-alias-plexSerifMedium);
   }
 
   :where(code, kbd, samp, pre) {
@@ -218,7 +220,7 @@
 }
 
 @utility title {
-  @apply text-accent-2 font-plex-serif text-2xl font-medium;
+  @apply text-accent-2 font-plex-serif-medium text-2xl font-medium;
 }
 
 @utility page-shell {
@@ -235,11 +237,11 @@
 }
 
 @utility page-title {
-  @apply text-accent-2 font-plex-serif text-4xl leading-tight font-medium sm:text-5xl;
+  @apply text-accent-2 font-plex-serif-medium text-4xl leading-tight font-medium sm:text-5xl;
 }
 
 @utility article-title {
-  @apply text-accent-2 font-plex-serif text-2xl leading-tight font-medium sm:text-4xl;
+  @apply text-accent-2 font-plex-serif-medium text-2xl leading-tight font-medium sm:text-4xl;
 }
 
 @utility subtitle {
@@ -248,7 +250,7 @@
 }
 
 @utility section-heading {
-  @apply text-accent font-plex-serif text-2xl font-medium;
+  @apply text-accent font-plex-serif-medium text-2xl font-medium;
 }
 
 @layer components {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -130,7 +130,7 @@
 /* Shadcn UI theme https://ui.shadcn.com/themes */
 :root {
   --radius: 0.5rem;
-  --background: oklch(97.86% 0.0026 106.45);
+  --background: oklch(97.86% 0.0035 96);
   --foreground: oklch(0.141 0.005 285.823); /* oklch(26.99% 0.0096 235.05) */
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.141 0.005 285.823);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -245,7 +245,7 @@
 }
 
 @utility subtitle {
-  @apply font-plex-serif mt-2 mb-8 max-w-3xl text-base leading-snug text-gray-700 italic sm:text-lg
+  @apply font-plex-serif mt-2 mb-8 max-w-3xl text-base leading-snug text-gray-700 sm:text-lg
     dark:text-gray-400;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,82 +1,11 @@
 /* would like to ignore ./src/pages/og-image/[slug].png.ts */
+@import url("https://cdn.jsdelivr.net/gh/tingjieguo/lxgw-bright-webfont/style.css");
 @import "tailwindcss";
 /* config for tailwindcss-typography plugin */
 @config "../../tailwind.config.ts";
 
 /* use a selector-based strategy for dark mode */
 @variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
-
-@font-face {
-  font-family: "Crimson Pro Variable";
-  font-style: normal;
-  font-display: swap;
-  font-weight: 200 900;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/crimson-pro:vf@latest/latin-wght-normal.woff2")
-    format("woff2-variations");
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
-    U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-@font-face {
-  font-family: "Crimson Pro Variable";
-  font-style: normal;
-  font-display: swap;
-  font-weight: 200 900;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/crimson-pro:vf@latest/latin-ext-wght-normal.woff2")
-    format("woff2-variations");
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
-    U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
-    U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-
-@font-face {
-  font-family: "Crimson Pro Variable";
-  font-style: italic;
-  font-display: swap;
-  font-weight: 200 900;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/crimson-pro:vf@latest/latin-wght-italic.woff2")
-    format("woff2-variations");
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
-    U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-@font-face {
-  font-family: "Crimson Pro Variable";
-  font-style: italic;
-  font-display: swap;
-  font-weight: 200 900;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/crimson-pro:vf@latest/latin-ext-wght-italic.woff2")
-    format("woff2-variations");
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
-    U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
-    U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-
-@font-face {
-  font-family: "LXGW WenKai";
-  font-style: normal;
-  font-display: swap;
-  font-weight: 300;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/lxgw-wenkai@latest/latin-300-normal.woff2")
-    format("woff2");
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
-    U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-@font-face {
-  font-family: "LXGW WenKai";
-  font-style: normal;
-  font-display: swap;
-  font-weight: 500;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/lxgw-wenkai@latest/latin-500-normal.woff2")
-    format("woff2");
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
-    U+2212, U+2215, U+FEFF, U+FFFD;
-}
 
 @font-face {
   font-family: "iA Writer Quattro";
@@ -201,7 +130,7 @@
 /* Shadcn UI theme https://ui.shadcn.com/themes */
 :root {
   --radius: 0.5rem;
-  --background: oklch(98.79% 0.0045 34.31);
+  --background: oklch(97.86% 0.0026 106.45);
   --foreground: oklch(0.141 0.005 285.823); /* oklch(26.99% 0.0096 235.05) */
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.141 0.005 285.823);
@@ -279,11 +208,9 @@
   --color-accent-2: oklch(18.15% 0 0);
   --color-quote: oklch(55.27% 0.195 19.06);
   /* --color-quote: var(--muted-foreground); */
-  --font-alias-plexSerif: "Crimson Pro Variable", "LXGW WenKai", "LXGW WenKai Lite",
-    ui-serif, Georgia, "Times New Roman", serif;
+  --font-alias-plexSerif: "LXGW Bright", ui-serif, serif;
   --font-alias-plexSans: "iA Writer Quattro", ui-sans-serif, system-ui, sans-serif;
-  --font-alias-writer: "Inter Variable", "LXGW WenKai Lite", ui-sans-serif, system-ui,
-    sans-serif;
+  --font-alias-writer: "LXGW Bright", ui-sans-serif, system-ui, sans-serif;
   --font-alias-plexMono: "iA Writer Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
     Consolas, "Liberation Mono", "Courier New", monospace;
   --font-plex-serif: var(--font-alias-plexSerif);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -218,7 +218,7 @@
 }
 
 @utility title {
-  @apply text-accent-2 font-plex-serif text-2xl font-semibold;
+  @apply text-accent-2 font-plex-serif text-2xl font-medium;
 }
 
 @utility page-shell {
@@ -235,11 +235,11 @@
 }
 
 @utility page-title {
-  @apply text-accent-2 font-plex-serif text-4xl leading-tight font-semibold sm:text-5xl;
+  @apply text-accent-2 font-plex-serif text-4xl leading-tight font-medium sm:text-5xl;
 }
 
 @utility article-title {
-  @apply text-accent-2 font-plex-serif text-2xl leading-tight font-semibold sm:text-4xl;
+  @apply text-accent-2 font-plex-serif text-2xl leading-tight font-medium sm:text-4xl;
 }
 
 @utility subtitle {
@@ -248,7 +248,7 @@
 }
 
 @utility section-heading {
-  @apply text-accent font-plex-serif text-2xl font-semibold;
+  @apply text-accent font-plex-serif text-2xl font-medium;
 }
 
 @layer components {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,4 @@
 /* would like to ignore ./src/pages/og-image/[slug].png.ts */
-@import url("https://cdn.jsdelivr.net/gh/tingjieguo/lxgw-bright-webfont/style.css");
 @import "tailwindcss";
 /* config for tailwindcss-typography plugin */
 @config "../../tailwind.config.ts";
@@ -41,54 +40,6 @@
   font-weight: 700;
   src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@latest/latin-700-italic.woff2")
     format("woff2");
-}
-
-@font-face {
-  font-family: "Inter Variable";
-  font-style: normal;
-  font-display: swap;
-  font-weight: 100 900;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-wght-normal.woff2")
-    format("woff2-variations");
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
-    U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-@font-face {
-  font-family: "Inter Variable";
-  font-style: normal;
-  font-display: swap;
-  font-weight: 100 900;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-ext-wght-normal.woff2")
-    format("woff2-variations");
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
-    U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
-    U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-
-@font-face {
-  font-family: "Inter Variable";
-  font-style: italic;
-  font-display: swap;
-  font-weight: 100 900;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-wght-italic.woff2")
-    format("woff2-variations");
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
-    U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-@font-face {
-  font-family: "Inter Variable";
-  font-style: italic;
-  font-display: swap;
-  font-weight: 100 900;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-ext-wght-italic.woff2")
-    format("woff2-variations");
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
-    U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
-    U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @font-face {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -159,7 +159,7 @@
   --color-accent-2: oklch(18.15% 0 0);
   --color-quote: oklch(55.27% 0.195 19.06);
   /* --color-quote: var(--muted-foreground); */
-  --font-alias-plexSerif: "LXGW Bright", ui-serif, serif;
+  --font-alias-plexSerif: "LXGW Bright Medium", "LXGW Bright", ui-serif, serif;
   --font-alias-plexSans: "iA Writer Quattro", ui-sans-serif, system-ui, sans-serif;
   --font-alias-writer: "LXGW Bright", ui-sans-serif, system-ui, sans-serif;
   --font-alias-plexMono: "iA Writer Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -163,12 +163,15 @@
   --font-alias-plexSerifMedium: "LXGW Bright Medium", "LXGW Bright", ui-serif, serif;
   --font-alias-plexSans: "iA Writer Quattro", ui-sans-serif, system-ui, sans-serif;
   --font-alias-writer: "LXGW Bright", ui-sans-serif, system-ui, sans-serif;
+  --font-alias-writerMedium: "LXGW Bright Medium", "LXGW Bright", ui-sans-serif, system-ui,
+    sans-serif;
   --font-alias-plexMono: "iA Writer Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
     Consolas, "Liberation Mono", "Courier New", monospace;
   --font-plex-serif: var(--font-alias-plexSerif);
   --font-plex-serif-medium: var(--font-alias-plexSerifMedium);
   --font-plex-sans: var(--font-alias-plexSans);
   --font-writer: var(--font-alias-writer);
+  --font-writer-medium: var(--font-alias-writerMedium);
   --font-plex-mono: var(--font-alias-plexMono);
   --font-sans: var(--font-alias-plexSans);
   --font-mono: var(--font-alias-plexMono);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -130,7 +130,7 @@
 /* Shadcn UI theme https://ui.shadcn.com/themes */
 :root {
   --radius: 0.5rem;
-  --background: oklch(97.86% 0.0035 96);
+  --background: oklch(97.86% 0.006 96);
   --foreground: oklch(0.141 0.005 285.823); /* oklch(26.99% 0.0096 235.05) */
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.141 0.005 285.823);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -162,9 +162,9 @@
   --font-alias-plexSerif: "LXGW Bright", "LXGW Bright Medium", ui-serif, serif;
   --font-alias-plexSerifMedium: "LXGW Bright Medium", "LXGW Bright", ui-serif, serif;
   --font-alias-plexSans: "iA Writer Quattro", ui-sans-serif, system-ui, sans-serif;
-  --font-alias-writer: "LXGW Bright", ui-sans-serif, system-ui, sans-serif;
-  --font-alias-writerMedium: "LXGW Bright Medium", "LXGW Bright", ui-sans-serif, system-ui,
-    sans-serif;
+  --font-alias-writer: "LXGW Bright", ui-serif, Georgia, "Times New Roman", serif;
+  --font-alias-writerMedium: "LXGW Bright Medium", "LXGW Bright", ui-serif, Georgia,
+    "Times New Roman", serif;
   --font-alias-plexMono: "iA Writer Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
     Consolas, "Liberation Mono", "Courier New", monospace;
   --font-plex-serif: var(--font-alias-plexSerif);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -33,7 +33,9 @@ export default {
               borderTopStyle: "solid",
             },
             em: {
+              fontFamily: "var(--font-alias-plexSerifMedium)",
               fontStyle: "normal",
+              fontWeight: "500",
             },
             strong: {
               fontFamily: "var(--font-alias-plexSerifMedium)",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -37,7 +37,6 @@ export default {
             },
             strong: {
               fontFamily: "var(--font-alias-writerMedium)",
-              fontStyle: "normal",
               fontWeight: "500",
             },
             sup: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -33,12 +33,10 @@ export default {
               borderTopStyle: "solid",
             },
             em: {
-              fontFamily: "var(--font-alias-plexSerifMedium)",
-              fontStyle: "normal",
-              fontWeight: "500",
+              fontStyle: "italic",
             },
             strong: {
-              fontFamily: "var(--font-alias-plexSerifMedium)",
+              fontFamily: "var(--font-alias-writerMedium)",
               fontStyle: "normal",
               fontWeight: "500",
             },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,8 +32,13 @@ export default {
             hr: {
               borderTopStyle: "solid",
             },
+            em: {
+              fontStyle: "normal",
+            },
             strong: {
-              fontWeight: "700",
+              fontFamily: "var(--font-alias-plexSerifMedium)",
+              fontStyle: "normal",
+              fontWeight: "500",
             },
             sup: {
               marginInlineStart: "calc(var(--spacing) * 0.5)",
@@ -63,7 +68,7 @@ export default {
             },
             "thead th": {
               borderBottom: "1px solid #666",
-              fontWeight: "700",
+              fontWeight: "500",
             },
             'th[align="center"], td[align="center"]': {
               "text-align": "center",


### PR DESCRIPTION
## Summary

- switch `plexSerif` and `writer` font stacks to `LXGW Bright`
- load the LXGW Bright webfont stylesheet from jsDelivr
- update the light theme background to the OKLCH equivalent of `rgb(248, 248, 246)`

## Validation

- `pnpm exec prettier --write src/styles/global.css`
- `pnpm build:site`
- verified current article page font/background behavior in the in-app browser