### PR TITLE
✨ feat(home): frosted-glass header & blog list polish

### DIFF
--- a/src/components/blog/HomePostPreview.astro
+++ b/src/components/blog/HomePostPreview.astro
@@ -14,7 +14,7 @@ const subtitle = post.data.subtitle?.trim();
 ---
 
 <a
-  class="focus-visible:outline-accent group -mx-3 block cursor-pointer px-3 transition-colors hover:bg-gray-200/10 focus-visible:bg-gray-200/10 focus-visible:outline-2 focus-visible:outline-offset-2"
+  class="focus-visible:outline-accent group border-foreground/5 block cursor-pointer border-t transition-colors hover:bg-gray-200/10 focus-visible:bg-gray-200/10 focus-visible:outline-2 focus-visible:-outline-offset-2 dark:border-white/5"
   data-astro-prefetch
   href={postUrl}
 >

--- a/src/components/blog/HomePostPreview.astro
+++ b/src/components/blog/HomePostPreview.astro
@@ -18,7 +18,7 @@ const subtitle = post.data.subtitle?.trim();
   data-astro-prefetch
   href={postUrl}
 >
-  <article class="grid gap-3 py-5 sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-8 sm:py-6">
+  <article class="grid gap-3 py-5 sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-8">
     <FormattedDate
       class="pt-1 text-xs text-gray-600 uppercase sm:text-right dark:text-gray-400"
       date={post.data.publishDate}

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -9,7 +9,7 @@ import { siteConfig } from "@/site.config";
   class="pointer-events-none sticky top-0 z-50 w-full"
 >
   <div
-    class="site-header-glass bg-background/95 supports-[backdrop-filter]:bg-background/60 [[data-collapsed=true]_&]:border-foreground/10 pointer-events-auto w-full border-b-0 border-solid border-transparent transition-colors [[data-collapsed=true]_&]:border-b"
+    class="site-header-glass bg-background/95 supports-[backdrop-filter]:bg-background/60 [[data-collapsed=true]_&]:border-foreground/10 pointer-events-auto w-full border-b-0 border-solid border-transparent transition [[data-collapsed=true]_&]:border-b"
   >
     <div class="site-header-shell page-shell relative z-10 flex items-start justify-between gap-4">
       <div>
@@ -58,7 +58,10 @@ import { siteConfig } from "@/site.config";
     /*
      * box-shadow stacks two layers via custom properties: a top rim highlight
      * (always on) and a drop shadow that stays invisible until the header
-     * collapses, when it lifts the bar a hair off the content below.
+     * collapses, when it lifts the bar a hair off the content below. The
+     * element carries Tailwind's `transition` utility (not `transition-colors`)
+     * so this box-shadow fades in/out on collapse instead of popping — the drop
+     * layer interpolates from transparent to its lifted value.
      */
     --header-glass-rim: oklch(100% 0 0 / 0.45);
     --header-glass-drop: 0 0 #0000;

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -9,7 +9,7 @@ import { siteConfig } from "@/site.config";
   class="pointer-events-none sticky top-0 z-50 w-full"
 >
   <div
-    class="bg-background/95 supports-[backdrop-filter]:bg-background/60 [[data-collapsed=true]_&]:border-foreground/10 pointer-events-auto w-full border-b-0 border-dotted border-transparent backdrop-blur-sm transition-colors [[data-collapsed=true]_&]:border-b"
+    class="site-header-glass bg-background/95 supports-[backdrop-filter]:bg-background/60 [[data-collapsed=true]_&]:border-foreground/10 pointer-events-auto w-full border-b-0 border-solid border-transparent transition-colors [[data-collapsed=true]_&]:border-b"
   >
     <div class="site-header-shell page-shell relative z-10 flex items-start justify-between gap-4">
       <div>
@@ -40,6 +40,43 @@ import { siteConfig } from "@/site.config";
     --header-tagline-opacity: 1;
 
     margin-bottom: var(--header-collapse-offset);
+  }
+
+  /*
+   * Frosted-glass material. A stronger blur plus a saturation boost makes
+   * content scrolling underneath read as "lit glass" rather than a flat tint,
+   * and the inset rim highlight mimics light catching the pane's top edge.
+   *
+   * This is deliberately *not* Apple's Liquid Glass: true refraction needs an
+   * SVG filter fed into backdrop-filter, which WebKit/Safari (iOS & macOS) does
+   * not support — so the effect tops out at frosted glass on our target OSes.
+   * Browsers without backdrop-filter fall back to the bg-background/95 tint.
+   */
+  .site-header-glass {
+    -webkit-backdrop-filter: blur(6px) saturate(180%);
+    backdrop-filter: blur(6px) saturate(180%);
+    /*
+     * box-shadow stacks two layers via custom properties: a top rim highlight
+     * (always on) and a drop shadow that stays invisible until the header
+     * collapses, when it lifts the bar a hair off the content below.
+     */
+    --header-glass-rim: oklch(100% 0 0 / 0.45);
+    --header-glass-drop: 0 0 #0000;
+    box-shadow:
+      inset 0 1px 0 0 var(--header-glass-rim),
+      var(--header-glass-drop);
+  }
+
+  :global([data-theme="dark"]) .site-header-glass {
+    --header-glass-rim: oklch(100% 0 0 / 0.12);
+  }
+
+  :global([data-collapsed="true"]) .site-header-glass {
+    --header-glass-drop: 0 1px 3px 0 oklch(0% 0 0 / 0.07);
+  }
+
+  :global([data-theme="dark"] [data-collapsed="true"]) .site-header-glass {
+    --header-glass-drop: 0 1px 4px 0 oklch(0% 0 0 / 0.32);
   }
 
   .site-header-shell {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,7 +33,7 @@ const latestNotes = allNotes.sort(collectionDateSort).slice(0, MAX_NOTES);
       <ul class="border-foreground/5 border-b dark:border-white/5" role="list">
         {
           allPostsByDate.map((p) => (
-            <li class="border-foreground/5 border-t dark:border-white/5">
+            <li>
               <HomePostPreview as="h3" post={p} />
             </li>
           ))


### PR DESCRIPTION
Three focused UI tweaks to the home page.

## ✨ Frosted-glass header — `62ac490`
- Swap the flat `backdrop-blur-sm` tint for a `backdrop-filter: blur(6px) saturate(180%)` frosted-glass material, with a top specular rim highlight and a drop shadow that only appears once the header collapses.
- Cross-browser including Safari/WebKit via `-webkit-backdrop-filter`; falls back to the existing `bg-background/95` tint where `backdrop-filter` is unsupported.
- **Deliberately *not* Apple Liquid Glass** — true refraction needs an SVG filter fed into `backdrop-filter`, which WebKit (iOS/macOS Safari) doesn't support, so the effect tops out at frosted glass on our target OSes. The code comments call this out.
- Bottom border switched `dotted` → `solid` (still only shown when collapsed).

## 🐛 Blog-row hover overflow — `240844a`
- **Bug:** on hover, the post-row fill poked ~12px past *each* end of the divider lines. Root cause: the divider lived on the `<li>` (content-column width) while the hover background lived on the `<a>`, which bled wider via `-mx-3 px-3` — two elements, two widths.
- **Fix:** move the divider onto the `<a>` so the border and the hover background share one box, and drop the bleed. Inner content position is unchanged (the old negative-margin/padding canceled out). The focus ring also switches to an inset offset so it stays within the frame.

## 💄 Blog-row padding — `7c90587`
- Drop the redundant `sm:py-6`; rows keep the base `py-5` rhythm at every breakpoint (a touch more compact on desktop).

## Testing
- Verified in the Astro dev server, light + dark, expanded + collapsed header.
- Hover fill now measures flush with the divider lines (`edgesAligned: true`, zero horizontal overflow); no new console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)