### PR TITLE
🔧 chore(footer): point GitHub link to daihaus org

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -7,7 +7,7 @@ import { siteConfig } from "@/site.config";
   <div class="page-shell py-10 text-gray-600 sm:flex-col dark:text-gray-400">
     <div class="grid items-center gap-x-4 gap-y-2 sm:grid-cols-[1fr_auto_1fr]">
       <a
-        href="https://github.com/xdanger/xdanger.com"
+        href="https://github.com/daihaus/xdanger.com"
         class="hover:text-accent focus-visible:ring-accent inline-flex items-center gap-2 justify-self-start rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         aria-label={`${siteConfig.author} on GitHub`}
       >


### PR DESCRIPTION
## What

Update the footer's GitHub link from `xdanger/xdanger.com` to `daihaus/xdanger.com`.

## Why

The repository now lives under the `daihaus` org, so the footer should link to the current canonical repo.

## Notes

- Only the footer repo link changed ([`src/components/layout/Footer.astro`](src/components/layout/Footer.astro)).
- The profile link in `src/components/SocialList.astro` (`github.com/xdanger`) is intentionally left untouched — it points to the user profile, not the repo.
- Verified locally on the Astro dev server: the rendered footer link resolves to `https://github.com/daihaus/xdanger.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)