### PR TITLE
🐛 fix(header): lock horizontal scroll & tighten collapsed bar

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -113,8 +113,15 @@ import { siteConfig } from "@/site.config";
     }
 
     /* Theme toggle eases down with the title so the collapsed row narrows to
-       20px (taking the fully-collapsed bar to ~44px) and the two stay matched. */
-    :global(#site-header theme-toggle button),
+       20px (taking the fully-collapsed bar to ~44px) and the two stay matched.
+       The button keeps a `color` transition so ThemeToggle's hover fade (its
+       `transition-colors` utility) survives this shorthand override. */
+    :global(#site-header theme-toggle button) {
+      transition:
+        color 150ms ease,
+        height 500ms ease,
+        width 500ms ease;
+    }
     :global(#site-header theme-toggle button svg) {
       transition:
         height 500ms ease,

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -13,9 +13,7 @@ import { siteConfig } from "@/site.config";
   >
     <div class="site-header-shell page-shell relative z-10 flex items-start justify-between gap-4">
       <div>
-        <p
-          class="text-accent-2 font-plex-serif-medium text-xl leading-none font-medium sm:text-2xl"
-        >
+        <p class="site-header-title text-accent-2 font-plex-serif-medium leading-none font-medium">
           <a href="/" data-astro-prefetch>{siteConfig.author}</a>
         </p>
         <p
@@ -92,9 +90,59 @@ import { siteConfig } from "@/site.config";
     opacity: var(--header-tagline-opacity);
   }
 
+  /* Mobile (< sm) keeps the title at text-xl and never shrinks it further. */
+  .site-header-title {
+    font-size: 1.25rem;
+  }
+
   @media (min-width: 640px) {
     .site-header-shell {
       padding-block: var(--header-padding-y-sm);
+    }
+
+    /* sm+ : the title stays text-2xl through the whole scroll-linked collapse,
+       then eases one notch to text-xl only once the bar is fully collapsed —
+       a single smooth transition at the final stage rather than a size that
+       tracks scroll position frame-by-frame (which read as abrupt). */
+    .site-header-title {
+      font-size: 1.5rem;
+      transition: font-size 500ms ease;
+    }
+    :global(#site-header[data-collapsed="true"]) .site-header-title {
+      font-size: 1.25rem;
+    }
+
+    /* Theme toggle eases down with the title so the collapsed row narrows to
+       20px (taking the fully-collapsed bar to ~44px) and the two stay matched. */
+    :global(#site-header theme-toggle button),
+    :global(#site-header theme-toggle button svg) {
+      transition:
+        height 500ms ease,
+        width 500ms ease;
+    }
+    :global(#site-header[data-collapsed="true"] theme-toggle button) {
+      height: 1.25rem;
+      width: 1.25rem;
+    }
+    :global(#site-header[data-collapsed="true"] theme-toggle button svg) {
+      height: 1rem;
+      width: 1rem;
+    }
+  }
+
+  /* Hold animations still while the script samples collapse geometry, and honor
+     reduced-motion. */
+  :global(#site-header.is-measuring) .site-header-title,
+  :global(#site-header.is-measuring theme-toggle button),
+  :global(#site-header.is-measuring theme-toggle button svg) {
+    transition: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .site-header-title,
+    :global(#site-header theme-toggle button),
+    :global(#site-header theme-toggle button svg) {
+      transition: none;
     }
   }
 
@@ -107,8 +155,8 @@ import { siteConfig } from "@/site.config";
 
 <script>
   const COMPACT_PADDING_Y = 12;
-  const COMPACT_PADDING_Y_SM = 16;
-  const COMPACT_PADDING_Y_MD = 16;
+  const COMPACT_PADDING_Y_SM = 12;
+  const COMPACT_PADDING_Y_MD = 12;
   const EXPANDED_PADDING_Y = 48;
   const EXPANDED_PADDING_Y_SM = 72;
   const EXPANDED_PADDING_Y_MD = 96;
@@ -144,12 +192,21 @@ import { siteConfig } from "@/site.config";
     const siteHeader = document.getElementById("site-header") as HTMLElement | null;
     if (!siteHeader) return;
 
+    // Measure with the title/toggle at full size (data-collapsed=false) and
+    // animations frozen, so the reads are exact regardless of the live state.
+    // The title shrink is a final-stage transition, so it must not count toward
+    // the collapse distance (otherwise the offset would over-compensate).
+    siteHeader.classList.add("is-measuring");
+    siteHeader.setAttribute("data-collapsed", "false");
+
     siteHeader.style.setProperty("--header-collapse-offset", "0px");
     setHeaderExpandedness(siteHeader, 1);
     const expandedHeight = siteHeader.getBoundingClientRect().height;
 
     setHeaderExpandedness(siteHeader, 0);
     const compactHeight = siteHeader.getBoundingClientRect().height;
+
+    siteHeader.classList.remove("is-measuring");
 
     compactScrollY = Math.max(expandedHeight - compactHeight, 1);
     updateHeaderCollapse();

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -29,7 +29,14 @@ const {
     />
   </head>
   <body class="bg-background antialiased dark:scrollbar-thumb-gray-700">
-    <div class="text-foreground flex min-h-svh min-w-svw flex-col text-sm">
+    {
+      /* overflow-x-clip contains any over-wide descendant so the page never
+        scrolls horizontally (which would slide the sticky header off-screen),
+        and clip keeps position:sticky working. A full-viewport min-width was
+        also dropped here: that unit counts the vertical scrollbar's width, so
+        it added a sliver of horizontal overflow on its own. */
+    }
+    <div class="text-foreground flex min-h-svh flex-col overflow-x-clip text-sm">
       <ThemeProvider />
       <SkipLink />
       <Header />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -183,6 +183,14 @@
     accent-color: var(--color-accent);
     min-height: 100%;
 
+    /* Kill the horizontal axis entirely: the page has no horizontal overflow,
+     * but a macOS trackpad can still rubber-band/two-finger-swipe the viewport
+     * sideways, dragging the sticky header off with it. overscroll-behavior-x
+     * is the only thing that stops elastic overscroll (overflow/clip can't).
+     * `-x` only, so vertical scrolling and its bounce are untouched.
+     * Trade-off: this also disables Chrome's two-finger swipe back/forward. */
+    overscroll-behavior-x: none;
+
     &[data-theme="light"] {
       color-scheme: light;
     }
@@ -345,5 +353,17 @@
 
   :where(code, kbd, samp) {
     font-family: var(--font-alias-plexMono);
+  }
+
+  /* Break long unbroken strings (URLs, hashes) so they wrap instead of
+   * widening the column and dragging the sticky header off on h-scroll. */
+  overflow-wrap: break-word;
+
+  /* Wide tables scroll inside their own box rather than overflowing the page.
+   * `display: block` is required for overflow to take effect on a table. */
+  :where(table) {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
   }
 }


### PR DESCRIPTION
## What & why

Two header/layout improvements from one session.

### 1. Lock the page to vertical scrolling — `e9e9ac0`
The sticky header slid off-screen when the page scrolled/swiped horizontally. Two stacked causes:

- **`min-w-svw`** (`min-width: 100svw`) on the body wrapper — `100svw` *includes* the vertical scrollbar width, so it forced a few px of real horizontal overflow whenever a classic scrollbar was present (invisible in headless/overlay-scrollbar browsers, visible in real Chrome).
- **Elastic overscroll** — the macOS trackpad could still rubber-band the viewport sideways even with zero scrollable width, dragging the sticky header with it.

Fixes:
- Removed `min-w-svw`; added `overflow-x: clip` on the content wrapper (`clip`, not `hidden`, so `position: sticky` keeps working).
- `overscroll-behavior-x: none` on `html` to stop the horizontal rubber-band. **Trade-off (intended):** this also disables Chrome's two-finger swipe back/forward.
- Wide tables now scroll inside their own box and long strings wrap, so content can't reintroduce horizontal overflow.

### 2. Tighter collapsed header — `a233693`
On `sm` and up, once the header finishes collapsing the "Kros Dai" title now eases one step down (text-2xl → text-xl) and the theme toggle shrinks to match, taking the collapsed bar from ~56px to ~44px.

- Implemented as a CSS `font-size`/size **transition (0.5s ease) at the final collapse stage** — smooth on any input device, rather than a size tracking scroll position frame-by-frame (which read as abrupt).
- **`< sm` screens untouched** (title stays text-xl, toggle 24px).
- Collapse-distance measurement freezes animations and measures at full size, so the final-stage shrink doesn't throw off the layout offset compensation.
- Respects `prefers-reduced-motion`.

## Reviewer notes
- The `overscroll-behavior-x: none` side effect (no swipe-back) is deliberate.
- The collapsed bar measures ~45px live (sub-pixel rounding of the 44px target).
- Verified on the dev server; `pnpm build` passes (1112 pages), `prettier`/`eslint`/`astro check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
