### PR TITLE
💄 style: typography & layout polish (type scale, links, dark theme, list pages)

### DIFF
--- a/src/components/AboutMe.astro
+++ b/src/components/AboutMe.astro
@@ -3,7 +3,7 @@ import SocialList from "@/components/SocialList.astro";
 import { Icon } from "astro-icon/components";
 ---
 
-<div>
+<div class="text-base">
   <ul class="list-none space-y-3 ps-0 leading-relaxed">
     <li class="ps-0">
       <Icon name="solar:chef-hat-heart-line-duotone" class="mr-2 inline-block h-5 w-5" />a father

--- a/src/components/AboutMe.astro
+++ b/src/components/AboutMe.astro
@@ -3,7 +3,7 @@ import SocialList from "@/components/SocialList.astro";
 import { Icon } from "astro-icon/components";
 ---
 
-<div class="text-base">
+<div class="text-[15px]">
   <ul class="list-none space-y-3 ps-0 leading-relaxed">
     <li class="ps-0">
       <Icon name="solar:chef-hat-heart-line-duotone" class="mr-2 inline-block h-5 w-5" />a father

--- a/src/components/SocialList.astro
+++ b/src/components/SocialList.astro
@@ -32,7 +32,7 @@ const socialLinks: {
 ---
 
 <div class="flex flex-wrap items-end">
-  <p>find <code class="text-accent">xdanger</code> on</p>
+  <p>find <code>xdanger</code> on</p>
   <ul class="flex flex-1 items-center gap-x-2 ps-2 sm:flex-initial">
     {
       socialLinks.map(({ friendlyName, isWebmention, link, icon }) => (

--- a/src/components/blog/HomePostPreview.astro
+++ b/src/components/blog/HomePostPreview.astro
@@ -20,9 +20,8 @@ const subtitle = post.data.subtitle?.trim();
 >
   <article class="grid gap-3 py-5 sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-8">
     <FormattedDate
-      class="pt-1 text-[13px] text-gray-600 uppercase sm:text-right dark:text-gray-400"
+      class="pt-1 text-xs text-gray-600 sm:text-right dark:text-gray-400"
       date={post.data.publishDate}
-      dateTimeOptions={{ day: "numeric" }}
     />
     <div>
       <Tag class="font-plex-serif text-base leading-tight text-pretty">

--- a/src/components/blog/HomePostPreview.astro
+++ b/src/components/blog/HomePostPreview.astro
@@ -17,7 +17,7 @@ const subtitle = post.data.subtitle?.trim();
   <Tag class="heading order-1 leading-tight text-pretty">
     {post.data.draft && <span class="text-red-500">(Draft) </span>}
     <a
-      class="text-accent-2 hover:text-accent focus-visible:text-accent focus-visible:outline-accent rounded-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
+      class="text-accent-2 focus-visible:text-accent focus-visible:outline-accent rounded-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
       data-astro-prefetch
       href={postUrl}
     >

--- a/src/components/blog/HomePostPreview.astro
+++ b/src/components/blog/HomePostPreview.astro
@@ -24,7 +24,7 @@ const subtitle = post.data.subtitle?.trim();
       date={post.data.publishDate}
     />
     <div>
-      <Tag class="font-plex-serif text-base leading-tight text-pretty">
+      <Tag class="font-plex-sans text-base leading-tight text-pretty">
         {post.data.draft && <span class="text-red-500">(Draft) </span>}
         <span
           class="text-accent-2 group-hover:text-accent group-focus-visible:text-accent transition-colors"

--- a/src/components/blog/HomePostPreview.astro
+++ b/src/components/blog/HomePostPreview.astro
@@ -13,33 +13,30 @@ const postUrl = getPostPath(post);
 const subtitle = post.data.subtitle?.trim();
 ---
 
-<a
-  class="focus-visible:outline-accent group border-foreground/5 block cursor-pointer border-t transition-colors hover:bg-gray-200/10 focus-visible:bg-gray-200/10 focus-visible:outline-2 focus-visible:-outline-offset-2 dark:border-white/5"
-  data-astro-prefetch
-  href={postUrl}
->
-  <article class="grid gap-3 py-5 sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-8">
-    <FormattedDate
-      class="date pt-1 text-gray-600 sm:text-right dark:text-gray-400"
-      date={post.data.publishDate}
-    />
-    <div>
-      <Tag class="heading leading-tight text-pretty">
-        {post.data.draft && <span class="text-red-500">(Draft) </span>}
-        <span
-          class="text-accent-2 group-hover:text-accent group-focus-visible:text-accent transition-colors"
-        >
-          <span class="sr-only">Read </span>
-          {post.data.title}
-        </span>
-      </Tag>
-      {
-        subtitle && (
-          <p class="font-plex-sans mt-2 max-w-2xl text-sm leading-snug text-gray-600 dark:text-gray-400">
-            {subtitle}
-          </p>
-        )
-      }
-    </div>
-  </article>
-</a>
+<article class="flex flex-wrap items-baseline gap-x-4 gap-y-2 py-5">
+  <Tag class="heading order-1 leading-tight text-pretty">
+    {post.data.draft && <span class="text-red-500">(Draft) </span>}
+    <a
+      class="text-accent-2 hover:text-accent focus-visible:text-accent focus-visible:outline-accent rounded-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
+      data-astro-prefetch
+      href={postUrl}
+    >
+      {post.data.title}
+    </a>
+  </Tag>
+  <span
+    aria-hidden="true"
+    class="border-foreground/5 order-2 hidden min-w-6 flex-1 self-center border-t sm:block dark:border-white/5"
+  ></span>
+  <FormattedDate
+    class="date order-3 shrink-0 text-gray-600 dark:text-gray-400"
+    date={post.data.publishDate}
+  />
+  {
+    subtitle && (
+      <p class="font-plex-sans order-2 w-full text-sm leading-snug text-gray-600 sm:order-4 dark:text-gray-400">
+        {subtitle}
+      </p>
+    )
+  }
+</article>

--- a/src/components/blog/HomePostPreview.astro
+++ b/src/components/blog/HomePostPreview.astro
@@ -20,12 +20,12 @@ const subtitle = post.data.subtitle?.trim();
 >
   <article class="grid gap-3 py-5 sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-8">
     <FormattedDate
-      class="pt-1 text-xs text-gray-600 uppercase sm:text-right dark:text-gray-400"
+      class="pt-1 text-[13px] text-gray-600 uppercase sm:text-right dark:text-gray-400"
       date={post.data.publishDate}
       dateTimeOptions={{ day: "numeric" }}
     />
     <div>
-      <Tag class="font-plex-serif text-lg leading-tight text-pretty sm:text-xl">
+      <Tag class="font-plex-serif text-base leading-tight text-pretty">
         {post.data.draft && <span class="text-red-500">(Draft) </span>}
         <span
           class="text-accent-2 group-hover:text-accent group-focus-visible:text-accent transition-colors"

--- a/src/components/blog/HomePostPreview.astro
+++ b/src/components/blog/HomePostPreview.astro
@@ -20,11 +20,11 @@ const subtitle = post.data.subtitle?.trim();
 >
   <article class="grid gap-3 py-5 sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-8">
     <FormattedDate
-      class="pt-1 text-xs text-gray-600 sm:text-right dark:text-gray-400"
+      class="date pt-1 text-gray-600 sm:text-right dark:text-gray-400"
       date={post.data.publishDate}
     />
     <div>
-      <Tag class="font-plex-sans text-base leading-tight text-pretty">
+      <Tag class="heading leading-tight text-pretty">
         {post.data.draft && <span class="text-red-500">(Draft) </span>}
         <span
           class="text-accent-2 group-hover:text-accent group-focus-visible:text-accent transition-colors"

--- a/src/components/blog/PostPreview.astro
+++ b/src/components/blog/PostPreview.astro
@@ -13,7 +13,10 @@ const { as: Tag = "div", post, withDesc = false } = Astro.props;
 const postUrl = getPostPath(post);
 ---
 
-<FormattedDate class="min-w-30 text-gray-600 dark:text-gray-400" date={post.data.publishDate} />
+<FormattedDate
+  class="date min-w-30 text-gray-600 dark:text-gray-400"
+  date={post.data.publishDate}
+/>
 <Tag class="leading-snug">
   {post.data.draft && <span class="text-red-500">(Draft) </span>}
   <a class="cactus-link text-foreground" data-astro-prefetch href={postUrl}>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -4,7 +4,7 @@ import { siteConfig } from "@/site.config";
 ---
 
 <footer class="flex min-h-15 flex-col">
-  <div class="page-shell py-10 text-[13px] text-gray-600 sm:flex-col dark:text-gray-400">
+  <div class="page-shell note py-10 text-gray-600 sm:flex-col dark:text-gray-400">
     <div class="grid items-center gap-x-4 gap-y-2 sm:grid-cols-[1fr_auto_1fr]">
       <a
         href="https://github.com/daihaus/xdanger.com"

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -9,7 +9,7 @@ import { siteConfig } from "@/site.config";
       <a
         href="https://github.com/daihaus/xdanger.com"
         class="focus-visible:ring-accent inline-flex items-center gap-2 justify-self-start rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-        aria-label={`${siteConfig.author} on GitHub`}
+        aria-label={`${siteConfig.author} on GitHub (opens in a new tab)`}
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -19,7 +19,7 @@ import { siteConfig } from "@/site.config";
       <a
         href="https://creativecommons.org/licenses/by-sa/4.0/"
         class="focus-visible:ring-accent inline-flex items-center gap-1 rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none max-sm:justify-self-start"
-        aria-label="CC BY-SA 4.0 Creative Commons Attribution-ShareAlike 4.0 International"
+        aria-label="CC BY-SA 4.0 Creative Commons Attribution-ShareAlike 4.0 International (opens in a new tab)"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -10,14 +10,18 @@ import { siteConfig } from "@/site.config";
         href="https://github.com/daihaus/xdanger.com"
         class="focus-visible:ring-accent inline-flex items-center gap-2 justify-self-start rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         aria-label={`${siteConfig.author} on GitHub`}
+        target="_blank"
+        rel="noopener noreferrer"
       >
         <Icon aria-hidden="true" class="h-5 w-5" focusable="false" name="mdi:github" />
-        <span>{siteConfig.author}</span>
+        <span>GitHub ↗</span>
       </a>
       <a
         href="https://creativecommons.org/licenses/by-sa/4.0/"
         class="focus-visible:ring-accent inline-flex items-center gap-1 rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none max-sm:justify-self-start"
         aria-label="CC BY-SA 4.0 Creative Commons Attribution-ShareAlike 4.0 International"
+        target="_blank"
+        rel="noopener noreferrer"
       >
         <Icon
           aria-hidden="true"
@@ -37,7 +41,7 @@ import { siteConfig } from "@/site.config";
           focusable="false"
           name="fa6-brands:creative-commons-sa"
         />
-        <span>CC BY-SA 4.0</span>
+        <span>CC BY-SA 4.0 ↗</span>
       </a>
       <span aria-hidden="true"></span>
     </div>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -4,7 +4,7 @@ import { siteConfig } from "@/site.config";
 ---
 
 <footer class="flex min-h-15 flex-col">
-  <div class="page-shell py-10 text-gray-600 sm:flex-col dark:text-gray-400">
+  <div class="page-shell py-10 text-[13px] text-gray-600 sm:flex-col dark:text-gray-400">
     <div class="grid items-center gap-x-4 gap-y-2 sm:grid-cols-[1fr_auto_1fr]">
       <a
         href="https://github.com/daihaus/xdanger.com"

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -16,7 +16,7 @@ import { siteConfig } from "@/site.config";
       </a>
       <a
         href="https://creativecommons.org/licenses/by-sa/4.0/"
-        class="hover:text-accent focus-visible:ring-accent inline-flex items-center gap-1 rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none max-sm:justify-self-center"
+        class="hover:text-accent focus-visible:ring-accent inline-flex items-center gap-1 rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none max-sm:justify-self-start"
         aria-label="CC BY-SA 4.0 Creative Commons Attribution-ShareAlike 4.0 International"
       >
         <Icon

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -8,7 +8,7 @@ import { siteConfig } from "@/site.config";
     <div class="grid items-center gap-x-4 gap-y-2 sm:grid-cols-[1fr_auto_1fr]">
       <a
         href="https://github.com/daihaus/xdanger.com"
-        class="hover:text-accent focus-visible:ring-accent inline-flex items-center gap-2 justify-self-start rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        class="focus-visible:ring-accent inline-flex items-center gap-2 justify-self-start rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         aria-label={`${siteConfig.author} on GitHub`}
       >
         <Icon aria-hidden="true" class="h-5 w-5" focusable="false" name="mdi:github" />
@@ -16,7 +16,7 @@ import { siteConfig } from "@/site.config";
       </a>
       <a
         href="https://creativecommons.org/licenses/by-sa/4.0/"
-        class="hover:text-accent focus-visible:ring-accent inline-flex items-center gap-1 rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none max-sm:justify-self-start"
+        class="focus-visible:ring-accent inline-flex items-center gap-1 rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none max-sm:justify-self-start"
         aria-label="CC BY-SA 4.0 Creative Commons Attribution-ShareAlike 4.0 International"
       >
         <Icon

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -41,9 +41,13 @@ import { siteConfig } from "@/site.config";
   }
 
   /*
-   * Frosted-glass material. A stronger blur plus a saturation boost makes
-   * content scrolling underneath read as "lit glass" rather than a flat tint,
-   * and the inset rim highlight mimics light catching the pane's top edge.
+   * Frosted-glass material: a 6px backdrop blur frosts content scrolling
+   * underneath. (Two earlier flourishes were dropped because they made the
+   * expanded header read differently from the body at the top of the page,
+   * where nothing sits behind the glass for them to act on: a saturate(180%)
+   * boost amplified the uniform background's chroma, and an inset 1px rim
+   * highlight drew a faint light line along the top edge — both showed up as a
+   * seam against the body in dark mode.)
    *
    * This is deliberately *not* Apple's Liquid Glass: true refraction needs an
    * SVG filter fed into backdrop-filter, which WebKit/Safari (iOS & macOS) does
@@ -51,25 +55,17 @@ import { siteConfig } from "@/site.config";
    * Browsers without backdrop-filter fall back to the bg-background/95 tint.
    */
   .site-header-glass {
-    -webkit-backdrop-filter: blur(6px) saturate(180%);
-    backdrop-filter: blur(6px) saturate(180%);
+    -webkit-backdrop-filter: blur(6px);
+    backdrop-filter: blur(6px);
     /*
-     * box-shadow stacks two layers via custom properties: a top rim highlight
-     * (always on) and a drop shadow that stays invisible until the header
-     * collapses, when it lifts the bar a hair off the content below. The
-     * element carries Tailwind's `transition` utility (not `transition-colors`)
-     * so this box-shadow fades in/out on collapse instead of popping — the drop
-     * layer interpolates from transparent to its lifted value.
+     * A drop shadow that stays invisible until the header collapses, when it
+     * lifts the bar a hair off the content below. The element carries Tailwind's
+     * `transition` utility (not `transition-colors`) so this box-shadow fades in
+     * on collapse instead of popping — the drop layer interpolates from
+     * transparent to its lifted value.
      */
-    --header-glass-rim: oklch(100% 0 0 / 0.45);
     --header-glass-drop: 0 0 #0000;
-    box-shadow:
-      inset 0 1px 0 0 var(--header-glass-rim),
-      var(--header-glass-drop);
-  }
-
-  :global([data-theme="dark"]) .site-header-glass {
-    --header-glass-rim: oklch(100% 0 0 / 0.12);
+    box-shadow: var(--header-glass-drop);
   }
 
   :global([data-collapsed="true"]) .site-header-glass {

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -81,6 +81,8 @@ import { siteConfig } from "@/site.config";
   }
 
   .site-header-tagline {
+    /* Bump one step over .note's 13px; the scoped selector outweighs the utility. */
+    font-size: 14px;
     margin-top: var(--header-tagline-margin-top);
     max-height: var(--header-tagline-max-height);
     opacity: var(--header-tagline-opacity);

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -17,7 +17,7 @@ import { siteConfig } from "@/site.config";
           <a href="/" data-astro-prefetch>{siteConfig.author}</a>
         </p>
         <p
-          class="site-header-tagline font-plex-mono max-w-2xl overflow-hidden text-[13px] leading-relaxed text-gray-600 dark:text-gray-400"
+          class="site-header-tagline note max-w-2xl overflow-hidden leading-relaxed text-gray-600 dark:text-gray-400"
         >
           Notes on tech, products, and life.
         </p>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -17,7 +17,7 @@ import { siteConfig } from "@/site.config";
           <a href="/" data-astro-prefetch>{siteConfig.author}</a>
         </p>
         <p
-          class="site-header-tagline font-plex-mono max-w-2xl overflow-hidden text-xs leading-relaxed text-gray-600 sm:text-sm dark:text-gray-400"
+          class="site-header-tagline font-plex-mono max-w-2xl overflow-hidden text-[13px] leading-relaxed text-gray-600 dark:text-gray-400"
         >
           Notes on tech, products, and life.
         </p>

--- a/src/components/note/Note.astro
+++ b/src/components/note/Note.astro
@@ -20,7 +20,7 @@ const noteUrl = `/notes/${note.id}`;
   ]}
   data-pagefind-body={!isPreview}
 >
-  <Tag class:list={[isPreview ? "title text-base" : "page-title mb-3"]}>
+  <Tag class:list={[isPreview ? "heading text-accent-2" : "page-title mb-3"]}>
     {
       isPreview ? (
         <a

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -23,7 +23,7 @@ const articleDate = updatedDate?.toISOString() ?? publishDate.toISOString();
   <article class="flex-colgrow flex break-words" data-pagefind-body>
     <div class="content-shell flex-col gap-10 py-4 sm:py-6 lg:flex-row lg:items-start">
       <div
-        class="prose prose-lg prose-headings:font-plex-serif-medium prose-headings:font-medium prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none max-w-3xl"
+        class="prose prose-base prose-headings:font-plex-serif-medium prose-headings:font-medium prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none max-w-3xl"
       >
         <slot />
         <WebMentions />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,13 +23,13 @@ const latestNotes = allNotes.sort(collectionDateSort).slice(0, MAX_NOTES);
   <h1 class="sr-only">{siteConfig.author}</h1>
   <section class="pt-0 pb-5 sm:pb-6">
     <div class="page-shell grid gap-6 md:grid-cols-[9rem_minmax(0,1fr)]">
-      <h2 class="section-heading">about</h2>
+      <h2 class="section">about</h2>
       <AboutMe />
     </div>
   </section>
   <section class="py-5 sm:py-6">
     <div class="page-shell grid gap-6 md:grid-cols-[9rem_minmax(0,1fr)]">
-      <h2 class="section-heading"><a href="/posts">blog</a></h2>
+      <h2 class="section"><a href="/posts">posts</a></h2>
       <ul
         class="border-foreground/5 border-b dark:border-white/5 [&>li:first-child>article]:pt-0"
         role="list"
@@ -48,7 +48,7 @@ const latestNotes = allNotes.sort(collectionDateSort).slice(0, MAX_NOTES);
     latestNotes.length > 0 && (
       <section class="py-5 sm:py-6">
         <div class="page-shell grid gap-6 md:grid-cols-[9rem_minmax(0,1fr)]">
-          <h2 class="section-heading">
+          <h2 class="section">
             <a href="/notes">notes</a>
           </h2>
           <ul class="grid gap-4 sm:grid-cols-2" role="list">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,10 +30,7 @@ const latestNotes = allNotes.sort(collectionDateSort).slice(0, MAX_NOTES);
   <section class="py-5 sm:py-6">
     <div class="page-shell grid gap-6 md:grid-cols-[9rem_minmax(0,1fr)]">
       <h2 class="section"><a href="/posts">posts</a></h2>
-      <ul
-        class="border-foreground/5 border-b dark:border-white/5 [&>li:first-child>article]:pt-0"
-        role="list"
-      >
+      <ul class="[&>li:first-child>article]:pt-0" role="list">
         {
           allPostsByDate.map((p) => (
             <li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,7 +22,7 @@ const latestNotes = allNotes.sort(collectionDateSort).slice(0, MAX_NOTES);
 <PageLayout meta={{ title: "Home" }}>
   <h1 class="sr-only">{siteConfig.author}</h1>
   <section class="pt-0 pb-5 sm:pb-6">
-    <div class="page-shell grid gap-6 md:grid-cols-[1fr_3fr]">
+    <div class="page-shell grid gap-6 md:grid-cols-[9rem_minmax(0,1fr)]">
       <h2 class="section-heading">about</h2>
       <AboutMe />
     </div>
@@ -30,7 +30,10 @@ const latestNotes = allNotes.sort(collectionDateSort).slice(0, MAX_NOTES);
   <section class="py-5 sm:py-6">
     <div class="page-shell grid gap-6 md:grid-cols-[9rem_minmax(0,1fr)]">
       <h2 class="section-heading"><a href="/posts">blog</a></h2>
-      <ul class="border-foreground/5 border-b dark:border-white/5" role="list">
+      <ul
+        class="border-foreground/5 border-b dark:border-white/5 [&>li:first-child>article]:pt-0"
+        role="list"
+      >
         {
           allPostsByDate.map((p) => (
             <li>
@@ -44,7 +47,7 @@ const latestNotes = allNotes.sort(collectionDateSort).slice(0, MAX_NOTES);
   {
     latestNotes.length > 0 && (
       <section class="py-5 sm:py-6">
-        <div class="page-shell grid gap-6 md:grid-cols-[1fr_3fr]">
+        <div class="page-shell grid gap-6 md:grid-cols-[9rem_minmax(0,1fr)]">
           <h2 class="section-heading">
             <a href="/notes">notes</a>
           </h2>

--- a/src/pages/notes/[...page].astro
+++ b/src/pages/notes/[...page].astro
@@ -5,7 +5,6 @@ import Note from "@/components/note/Note.astro";
 import PageLayout from "@/layouts/Base.astro";
 import { collectionDateSort } from "@/utils/date";
 import type { GetStaticPaths } from "astro";
-import { Icon } from "astro-icon/components";
 
 export const getStaticPaths = (async ({ paginate }) => {
   const MAX_NOTES_PER_PAGE = 20;
@@ -41,12 +40,7 @@ const paginationProps = {
 <PageLayout meta={meta}>
   <section class="page-section pt-0">
     <div class="page-shell">
-      <h1 class="page-title mb-10 flex items-center gap-3">
-        Notes <a class="text-accent" href="/notes/rss.xml" target="_blank">
-          <span class="sr-only">RSS feed</span>
-          <Icon aria-hidden="true" class="h-6 w-6" focusable="false" name="mdi:rss" />
-        </a>
-      </h1>
+      <h1 class="sr-only">Notes</h1>
       <ul class="grid gap-5 text-start sm:grid-cols-2">
         {
           page.data.map((note) => (

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -65,7 +65,7 @@ const descYearKeys = Object.keys(groupedByYear).sort((a, b) => +b - +a);
           {
             descYearKeys.map((yearKey) => (
               <section aria-labelledby={`year-${yearKey}`}>
-                <h2 id={`year-${yearKey}`} class="section-heading">
+                <h2 id={`year-${yearKey}`} class="section">
                   <span class="sr-only">Posts in</span>
                   {yearKey}
                 </h2>

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -6,7 +6,6 @@ import PageLayout from "@/layouts/Base.astro";
 import { collectionDateSort } from "@/utils/date";
 // import type { GetStaticPaths, Page } from "astro";
 import type { GetStaticPaths } from "astro";
-import { Icon } from "astro-icon/components";
 
 export const getStaticPaths = (async ({ paginate }) => {
   const MAX_POSTS_PER_PAGE = 40;
@@ -53,23 +52,17 @@ const descYearKeys = Object.keys(groupedByYear).sort((a, b) => +b - +a);
 <PageLayout meta={meta}>
   <section class="page-section pt-0">
     <div class="page-shell">
-      <div class="mb-10 flex items-center gap-3">
-        <h1 class="page-title">Posts</h1>
-        <a class="text-accent" href="/rss.xml" target="_blank">
-          <span class="sr-only">RSS feed</span>
-          <Icon aria-hidden="true" class="h-6 w-6" focusable="false" name="mdi:rss" />
-        </a>
-      </div>
+      <h1 class="sr-only">Posts</h1>
       <div class="grid gap-12 lg:grid-cols-[minmax(0,1fr)_14rem]">
         <div>
           {
             descYearKeys.map((yearKey) => (
               <section aria-labelledby={`year-${yearKey}`}>
-                <h2 id={`year-${yearKey}`} class="section">
+                <h2 id={`year-${yearKey}`} class="section font-writer">
                   <span class="sr-only">Posts in</span>
                   {yearKey}
                 </h2>
-                <ul class="mt-5 mb-16 space-y-4 text-start">
+                <ul class="mt-5 mb-10 space-y-4 text-start">
                   {groupedByYear[yearKey]?.map((p) => (
                     <li class="grid gap-2 sm:grid-cols-[auto_1fr] sm:[&_q]:col-start-2">
                       <PostPreview post={p} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -338,8 +338,7 @@
 }
 
 @utility subtitle {
-  @apply font-plex-serif mt-2 mb-8 max-w-3xl text-base leading-snug text-gray-700 sm:text-lg
-    dark:text-gray-400;
+  @apply mt-2 mb-8 max-w-3xl text-base leading-snug text-gray-700 sm:text-lg dark:text-gray-400;
 }
 
 @utility section-heading {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -268,7 +268,7 @@
     background-color: var(--color-background);
   }
   /* Default heading family is writer (Inter). The named title utilities
-   * (page-title, article-title, section-heading, title) and prose headings opt
+   * (page-title, article-title, title) and prose headings opt
    * back into plexSerif themselves; this is just the fallback for "naked"
    * headings. Plain (not :where) so font-weight beats Preflight's
    * `h1, h2, h3, h4, h5, h6 { font-weight: inherit }` — Inter Variable spans the
@@ -375,8 +375,8 @@ a.not-prose {
   @apply mt-2 mb-8 max-w-3xl text-base leading-snug text-gray-700 sm:text-lg dark:text-gray-400;
 }
 
-@utility section-heading {
-  @apply text-accent font-plex-serif-medium text-2xl font-medium;
+@utility section {
+  @apply font-plex-sans text-xl font-medium;
 }
 
 @layer components {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -306,14 +306,18 @@
   scrollbar-color: var(--border) transparent;
 }
 
-/* Site-wide link affordance: every link reads as a link via a faint 1px underline
- * that darkens to the text colour on hover (hover just drops the faded color back
- * to currentColor). Unlayered on purpose so it overrides Preflight, the prose
- * plugin, and cactus-link for one consistent treatment — no `.no-underline`
- * opt-outs exist in the codebase. Opted out: the header/footer chrome, icon/avatar
- * links (:has(svg, img)) where the line would cross the graphic, and `.not-prose`
- * links (heading self-anchors, webmention avatars) — kept in a separate rule so a
- * class selector doesn't outweigh the chrome exclusion. */
+/* Two link treatments site-wide, both unlayered so they override Preflight, the
+ * prose plugin, and cactus-link for one consistent system:
+ *   A — chrome (header/footer) and section headings (.section): no underline;
+ *       the text itself shifts to the accent colour on hover.
+ *   B — every other link, incl. post/note titles (.heading): a faint 1px
+ *       underline whose colour firms up to accent on hover.
+ * Icon/avatar links (:has(svg, img)) are excluded from the underline so the line
+ * doesn't cross the graphic; `.not-prose` links (article heading self-anchors,
+ * webmention avatars) keep their own treatment, so they only opt out of the
+ * underline. */
+
+/* Style B — content links: underlined, underline turns accent on hover. */
 a:not(:has(svg, img)) {
   text-decoration-line: underline;
   text-decoration-thickness: 1px;
@@ -321,11 +325,20 @@ a:not(:has(svg, img)) {
   text-decoration-color: color-mix(in oklab, currentColor 30%, transparent);
 }
 a:not(:has(svg, img)):hover {
-  text-decoration-color: currentColor;
+  text-decoration-color: var(--color-accent);
 }
+
+/* Style A — chrome + section headings: no underline, text turns accent on hover.
+ * Listed after Style B so the no-underline wins the same-specificity tie for
+ * header/footer links. */
 :is(header, footer) a,
+.section a,
 a.not-prose {
   text-decoration-line: none;
+}
+:is(header, footer) a:hover,
+.section a:hover {
+  color: var(--color-accent);
 }
 
 @utility cactus-link {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -287,6 +287,18 @@
   :where(code, kbd, samp, pre) {
     font-family: var(--font-alias-plexMono);
   }
+
+  /* Inline-code chip for non-article code (e.g. the "xdanger" handle): a faint
+   * neutral background like a chat UI, instead of the red accent that reads as a
+   * link. Scoped out of article `prose` (the typography plugin owns that) and
+   * out of code blocks (`pre code`). */
+  code:not(:where(pre code, .prose code)) {
+    border-radius: 0.25rem;
+    background-color: color-mix(in oklab, var(--color-foreground) 5%, transparent);
+    padding-inline: 0.375rem;
+    padding-block: 0.125rem;
+    font-size: 0.9em;
+  }
 }
 
 * {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,7 +11,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@latest/latin-400-normal.woff2")
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@5/latin-400-normal.woff2")
     format("woff2");
 }
 
@@ -20,7 +20,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@latest/latin-400-italic.woff2")
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@5/latin-400-italic.woff2")
     format("woff2");
 }
 
@@ -29,7 +29,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@latest/latin-700-normal.woff2")
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@5/latin-700-normal.woff2")
     format("woff2");
 }
 
@@ -38,7 +38,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@latest/latin-700-italic.woff2")
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-quattro@5/latin-700-italic.woff2")
     format("woff2");
 }
 
@@ -47,7 +47,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 400;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-mono@latest/latin-400-normal.woff2")
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-mono@5/latin-400-normal.woff2")
     format("woff2");
 }
 
@@ -56,7 +56,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 400;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-mono@latest/latin-400-italic.woff2")
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-mono@5/latin-400-italic.woff2")
     format("woff2");
 }
 
@@ -65,7 +65,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 700;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-mono@latest/latin-700-normal.woff2")
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-mono@5/latin-700-normal.woff2")
     format("woff2");
 }
 
@@ -74,7 +74,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 700;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-mono@latest/latin-700-italic.woff2")
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/ia-writer-mono@5/latin-700-italic.woff2")
     format("woff2");
 }
 
@@ -87,7 +87,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 100 900;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-wght-normal.woff2")
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@5/latin-wght-normal.woff2")
     format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
     U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -99,7 +99,7 @@
   font-style: normal;
   font-display: swap;
   font-weight: 100 900;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-ext-wght-normal.woff2")
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@5/latin-ext-wght-normal.woff2")
     format("woff2");
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
     U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,
@@ -111,7 +111,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 100 900;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-wght-italic.woff2")
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@5/latin-wght-italic.woff2")
     format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
     U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -123,7 +123,7 @@
   font-style: italic;
   font-display: swap;
   font-weight: 100 900;
-  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-ext-wght-italic.woff2")
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@5/latin-ext-wght-italic.woff2")
     format("woff2");
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
     U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -267,14 +267,15 @@
     min-height: 100%;
     background-color: var(--color-background);
   }
-  /* Plain (not :where) so font-weight beats Preflight's
-   * `h1, h2, h3, h4, h5, h6 { font-weight: inherit }`. The old "LXGW Bright
-   * Medium" family carried only the Medium cut, so headings rendered Medium with
-   * no explicit weight; the new single-family source needs weight 500 stated
-   * outright. Utilities (font-medium, prose typography) sit in later layers and
-   * still override both. */
+  /* Default heading family is writer (Inter). The named title utilities
+   * (page-title, article-title, section-heading, title) and prose headings opt
+   * back into plexSerif themselves; this is just the fallback for "naked"
+   * headings. Plain (not :where) so font-weight beats Preflight's
+   * `h1, h2, h3, h4, h5, h6 { font-weight: inherit }` — Inter Variable spans the
+   * full weight range, so 500 is stated outright. Utilities (font-medium, the
+   * named title utilities, prose typography) sit in later layers and override. */
   h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-alias-plexSerifMedium);
+    font-family: var(--font-alias-writer);
     font-weight: 500;
   }
   /* Only the top two headings keep Medium; h3–h6 drop to normal weight so CJK

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -78,6 +78,58 @@
     format("woff2");
 }
 
+/* Inter (variable) via Fontsource CDN — https://fontsource.org/fonts/inter/cdn.
+ * latin + latin-ext subsets, each weight 100–900 in one file. unicode-range lets
+ * the browser fetch only the subset a page actually needs. CJK is not in Inter, so
+ * it falls back per the --font-alias-writer stack. */
+@font-face {
+  font-family: "Inter Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-wght-normal.woff2")
+    format("woff2-variations");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+    U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Inter Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-ext-wght-normal.woff2")
+    format("woff2-variations");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
+    U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,
+    U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+@font-face {
+  font-family: "Inter Variable";
+  font-style: italic;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-wght-italic.woff2")
+    format("woff2-variations");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+    U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Inter Variable";
+  font-style: italic;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-ext-wght-italic.woff2")
+    format("woff2-variations");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
+    U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,
+    U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
 /* Shadcn UI theme https://ui.shadcn.com/themes */
 :root {
   --radius: 0.5rem;
@@ -159,13 +211,17 @@
   --color-accent-2: oklch(18.15% 0 0);
   --color-quote: oklch(55.27% 0.195 19.06);
   /* --color-quote: var(--muted-foreground); */
+  /* Four type families. The Latin-only faces (iA Writer, Inter) lean on the
+   * generic families below — the browser picks the right system font per platform
+   * and substitutes the system CJK font for glyphs the webfont lacks. */
+  --font-alias-plexSans: "iA Writer Quattro", ui-sans-serif, system-ui, -apple-system, sans-serif;
   --font-alias-plexSerif: "LXGW Bright", ui-serif, serif;
-  --font-alias-plexSerifMedium: "LXGW Bright", ui-serif, serif;
-  --font-alias-plexSans: "iA Writer Quattro", ui-sans-serif, system-ui, sans-serif;
-  --font-alias-writer: "LXGW Bright", ui-serif, Georgia, "Times New Roman", serif;
-  --font-alias-writerMedium: "LXGW Bright", ui-serif, Georgia, "Times New Roman", serif;
-  --font-alias-plexMono: "iA Writer Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
-    Consolas, "Liberation Mono", "Courier New", monospace;
+  --font-alias-plexMono: "iA Writer Mono", ui-monospace, monospace;
+  --font-alias-writer: "Inter Variable", "Inter", ui-sans-serif, system-ui, -apple-system,
+    sans-serif;
+  /* Medium cuts reuse the same family; weight comes from font-medium / 500. */
+  --font-alias-plexSerifMedium: var(--font-alias-plexSerif);
+  --font-alias-writerMedium: var(--font-alias-writer);
   --font-plex-serif: var(--font-alias-plexSerif);
   --font-plex-serif-medium: var(--font-alias-plexSerifMedium);
   --font-plex-sans: var(--font-alias-plexSans);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -221,6 +221,11 @@
     font-family: var(--font-alias-plexSerifMedium);
     font-weight: 500;
   }
+  /* Only the top two headings keep Medium; h3–h6 drop to normal weight so CJK
+   * glyphs falling back to the system font don't read as heavy at 500. */
+  h3, h4, h5, h6 {
+    font-weight: normal;
+  }
 
   :where(code, kbd, samp, pre) {
     font-family: var(--font-alias-plexMono);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -88,7 +88,7 @@
   font-display: swap;
   font-weight: 100 900;
   src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-wght-normal.woff2")
-    format("woff2-variations");
+    format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
     U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
     U+FEFF, U+FFFD;
@@ -100,7 +100,7 @@
   font-display: swap;
   font-weight: 100 900;
   src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-ext-wght-normal.woff2")
-    format("woff2-variations");
+    format("woff2");
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
     U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,
     U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -112,7 +112,7 @@
   font-display: swap;
   font-weight: 100 900;
   src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-wght-italic.woff2")
-    format("woff2-variations");
+    format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
     U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
     U+FEFF, U+FFFD;
@@ -124,7 +124,7 @@
   font-display: swap;
   font-weight: 100 900;
   src: url("https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-ext-wght-italic.woff2")
-    format("woff2-variations");
+    format("woff2");
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
     U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0,
     U+2113, U+2C60-2C7F, U+A720-A7FF;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -294,6 +294,28 @@
   scrollbar-color: var(--border) transparent;
 }
 
+/* Site-wide link affordance: every link reads as a link via a faint 1px underline
+ * that darkens to the text colour on hover (hover just drops the faded color back
+ * to currentColor). Unlayered on purpose so it overrides Preflight, the prose
+ * plugin, and cactus-link for one consistent treatment — no `.no-underline`
+ * opt-outs exist in the codebase. Opted out: the header/footer chrome, icon/avatar
+ * links (:has(svg, img)) where the line would cross the graphic, and `.not-prose`
+ * links (heading self-anchors, webmention avatars) — kept in a separate rule so a
+ * class selector doesn't outweigh the chrome exclusion. */
+a:not(:has(svg, img)) {
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+  text-decoration-color: color-mix(in oklab, currentColor 30%, transparent);
+}
+a:not(:has(svg, img)):hover {
+  text-decoration-color: currentColor;
+}
+:is(header, footer) a,
+a.not-prose {
+  text-decoration-line: none;
+}
+
 @utility cactus-link {
   @apply hover:decoration-link underline underline-offset-2 hover:decoration-2;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -252,7 +252,7 @@
 
     &[data-theme="dark"] {
       color-scheme: dark;
-      --color-background: oklch(23.64% 0.0045 248);
+      --color-background: oklch(23.64% 0 0);
       --color-foreground: oklch(83.54% 0 264);
       --color-primary: oklch(0.546 0.245 262.881);
       --color-primary-foreground: oklch(0.379 0.146 265.522);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -301,6 +301,20 @@
   @apply text-accent-2 font-plex-serif-medium text-2xl font-medium;
 }
 
+/* Reusable inline typography classes, applied element-by-element.
+ * note → body-ish small sans; date → mono timestamps; heading → small writer-font title. */
+@utility note {
+  @apply font-plex-sans text-[13px];
+}
+
+@utility date {
+  @apply font-plex-mono text-[13px];
+}
+
+@utility heading {
+  @apply font-writer text-base;
+}
+
 @utility page-shell {
   @apply container mx-auto max-w-3xl px-4 sm:px-6;
 }


### PR DESCRIPTION
## What

A run of interactive typography and layout refinements across the site — homepage, list pages, header/footer, link treatments, and the dark theme. All changes are presentational (CSS + markup), no behavioral or data changes.

### Type system
- Add reusable type classes: `.note`, `.date`, `.heading`, and a `.section` label class (`plexSans · 20px · medium`).
- Consolidate font aliases and load Inter Variable; default naked headings to the writer (Inter) face.
- Section headings on the homepage use the new `.section` class instead of the old `section-heading` utility.

### Homepage
- Align the `about` / `posts` / `notes` content columns to a shared `9rem` label grid; drop the first post's top padding so it lines up with its section label.
- Redesign the post list with leader-line rows; normalize dates to `May 04, 2025`.
- Drop the trailing divider under the post list.

### Link treatments (site-wide, two styles)
- **Chrome & headings** (header, footer, `.section` heading links): no underline; hover turns the text the accent color.
- **Content links** (incl. post titles): faint 30% underline; hover turns the underline the accent color.
- Inline `code` (e.g. the handle chip) is now a subtle gray background chip instead of red text, so it no longer reads as a link.

### Header
- Drop the glass `saturate()` and rim highlight that made the dark header look seamed against the body.
- Bump the tagline to 14px.

### Dark theme
- Neutralize the dark `--color-background` chroma to remove a faint green/teal cast (`rgb(29,31,32)` → `rgb(30,30,30)`).

### Footer
- Left-align the cells when stacked; apply the `.note` class.
- Label external links (`GitHub ↗`, `CC BY-SA 4.0 ↗`) and open them in a new tab.

### Posts / Notes list pages
- Remove the page title bar + RSS icon (feeds are still advertised in `<head>`); keep an `sr-only` `<h1>` for a11y/SEO.
- Year headings use `.section` sizing with the writer font (proportional figures, not monospaced).
- Row dates use the `.date` utility; tighten the year-group gap.

## Why
Ongoing hand-tuning of the site's typography and spacing for a more consistent, quieter reading experience.

## Reviewer notes
- `.section` applies `plexSans` (iA Writer Quattro), which has **monospaced figures** — year headings deliberately add `font-writer` so digits render proportionally.
- Removing the visible RSS icons does **not** orphan the feeds; `<link rel="alternate" type="application/rss+xml">` is still emitted from `BaseHead` for both `/rss.xml` and `/notes/rss.xml`.
- The two link styles rely on unlayered rules beating Tailwind's layered utilities; `.heading` (index post titles) is intentionally Style B (underlined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
