### PR TITLE
✨ feat(dev): serve HTTPS over Tailscale via anyip.dev for remote debugging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,8 @@ pnpm cert:anyip
 Then run `pnpm dev` and open `https://<dashed-ip>.anyip.dev:4321`, where `<dashed-ip>` is this
 machine's Tailscale IP with dots written as dashes — look it up with `tailscale ip -4` (e.g.
 `100.77.4.5` → `100-77-4-5`). HMR works over the same port with no extra config. The mechanism
-(anyip resolves the embedded IP back, plus a public-key Let's Encrypt wildcard for `*.anyip.dev`)
-is documented in the note atop `astro.config.ts`.
+(anyip resolves the embedded IP back, plus a Let's Encrypt wildcard cert for `*.anyip.dev` whose
+private key is intentionally public) is documented in the note atop `astro.config.ts`.
 
 ### File-level checks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,10 @@ machine's Tailscale IP with dots written as dashes — look it up with `tailscal
 (anyip resolves the embedded IP back, plus a Let's Encrypt wildcard cert for `*.anyip.dev` whose
 private key is intentionally public) is documented in the note atop `astro.config.ts`.
 
+> **Heads-up:** with the cert present the dev server binds to all interfaces (`0.0.0.0`), so it's
+> reachable not only over Tailscale but on any LAN the machine is attached to — enable it only on
+> networks you trust, or add a firewall rule. Without the cert, `pnpm dev` stays on `localhost`.
+
 ### File-level checks
 
 When you edit a file by hand, run the appropriate checks before committing:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,25 @@ pnpm lint           # autocorrect + prettier --check + eslint + astro check
 pnpm fix            # autocorrect + prettier --write + eslint --fix
 ```
 
+### Remote debugging over Tailscale
+
+`pnpm dev` auto-serves **HTTPS** when an [anyip.dev](https://anyip.dev) wildcard cert is present
+in `.cert/anyip/`, making the dev server reachable from any device on the tailnet with a
+browser-trusted TLS cert (handy for mobile / secure-context testing). Without the cert it falls
+back to plain HTTP on localhost, so the default local flow is unchanged.
+
+```bash
+# One-time: fetch the cert (git-ignored via *.pem; re-download ~every 90 days when it expires)
+curl -o .cert/anyip/fullchain.pem https://anyip.dev/cert/fullchain.pem
+curl -o .cert/anyip/privkey.pem   https://anyip.dev/cert/privkey.pem
+```
+
+Then run `pnpm dev` and open `https://<dashed-ip>.anyip.dev:4321`, where `<dashed-ip>` is this
+machine's Tailscale IP with dots written as dashes — look it up with `tailscale ip -4` (e.g.
+`100.77.4.5` → `100-77-4-5`). HMR works over the same port with no extra config. The mechanism
+(anyip resolves the embedded IP back, plus a public-key Let's Encrypt wildcard for `*.anyip.dev`)
+is documented in the note atop `astro.config.ts`.
+
 ### File-level checks
 
 When you edit a file by hand, run the appropriate checks before committing:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ etc.) working in this repository.
 ```bash
 pnpm install        # install deps
 pnpm dev            # local dev server
+pnpm cert:anyip     # fetch anyip TLS cert so `pnpm dev` serves HTTPS (Tailscale remote debug)
 pnpm build          # production build, including pagefind search index
 pnpm build:site     # Astro-only build for faster local rebuild checks
 pnpm build:debug    # Astro build with NODE_OPTIONS=--trace-warnings
@@ -46,9 +47,8 @@ browser-trusted TLS cert (handy for mobile / secure-context testing). Without th
 back to plain HTTP on localhost, so the default local flow is unchanged.
 
 ```bash
-# One-time: fetch the cert (git-ignored via *.pem; re-download ~every 90 days when it expires)
-curl -o .cert/anyip/fullchain.pem https://anyip.dev/cert/fullchain.pem
-curl -o .cert/anyip/privkey.pem   https://anyip.dev/cert/privkey.pem
+# One-time; re-run ~every 90 days when the cert expires. Saves into .cert/anyip/ (git-ignored).
+pnpm cert:anyip
 ```
 
 Then run `pnpm dev` and open `https://<dashed-ip>.anyip.dev:4321`, where `<dashed-ip>` is this

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -33,22 +33,33 @@ import rehypeUnwrapImages from "rehype-unwrap-images";
 // Then open e.g. https://100-77-4-5.anyip.dev:4321 (your Tailscale IP, dashed).
 const anyipCert = "./.cert/anyip/fullchain.pem";
 const anyipKey = "./.cert/anyip/privkey.pem";
-const devHttps =
-  fs.existsSync(anyipCert) && fs.existsSync(anyipKey)
-    ? { cert: fs.readFileSync(anyipCert), key: fs.readFileSync(anyipKey) }
-    : undefined;
+// Guarded: this also runs during `pnpm build`, so a corrupt/unreadable cert
+// must never abort the build — fall back to plain HTTP dev instead.
+const devHttps = (() => {
+  try {
+    if (fs.existsSync(anyipCert) && fs.existsSync(anyipKey)) {
+      return { cert: fs.readFileSync(anyipCert), key: fs.readFileSync(anyipKey) };
+    }
+  } catch {
+    // fall through to undefined
+  }
+  return undefined;
+})();
 
 // https://astro.build/config
 export default defineConfig({
   // adapter: vercel(),
-  // Dev/preview server — listen on all interfaces so it's reachable over
-  // Tailscale (MagicDNS host `*.hound-manta.ts.net`) for remote debugging.
-  // The leading dot in `allowedHosts` whitelists every machine in the tailnet.
-  server: {
-    host: true,
-    port: 4321,
-    allowedHosts: [".hound-manta.ts.net", ".anyip.dev"],
-  },
+  // Dev server. Only bind to all interfaces when the anyip cert is present
+  // (i.e. you've opted into HTTPS remote debugging over Tailscale). Without the
+  // cert, fall back to Astro's localhost-only default so a plain `pnpm dev` is
+  // never exposed to the LAN.
+  //
+  // No `allowedHosts` here: Vite skips its host-header allowlist entirely when
+  // the dev server runs over HTTPS (https://vite.dev/config/server-options),
+  // so it can't guard this path. DNS-rebinding is instead limited by Vite's
+  // default CORS policy (only localhost origins may read responses) plus
+  // keeping this all-interfaces bind gated behind the HTTPS opt-in above.
+  server: devHttps ? { host: true, port: 4321 } : undefined,
   build: {
     // https://docs.astro.build/zh-cn/reference/configuration-reference/#buildformat
     format: "preserve",

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -29,9 +29,7 @@ import rehypeUnwrapImages from "rehype-unwrap-images";
 // public — same security as plain HTTP, which is fine since Tailscale already
 // encrypts the transport). Drop the cert into `.cert/anyip/` (git-ignored via
 // *.pem) and the dev server auto-serves HTTPS so secure-context APIs work:
-//   mkdir -p .cert/anyip
-//   curl -o .cert/anyip/fullchain.pem https://anyip.dev/cert/fullchain.pem
-//   curl -o .cert/anyip/privkey.pem   https://anyip.dev/cert/privkey.pem
+//   pnpm cert:anyip   # downloads fullchain.pem + privkey.pem into .cert/anyip/
 // Then open e.g. https://100-77-4-5.anyip.dev:4321 (your Tailscale IP, dashed).
 const anyipCert = "./.cert/anyip/fullchain.pem";
 const anyipKey = "./.cert/anyip/privkey.pem";

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -23,9 +23,34 @@ import rehypeExternalLinks from "rehype-external-links";
 import rehypeKatex from "rehype-katex";
 import rehypeUnwrapImages from "rehype-unwrap-images";
 
+// Optional HTTPS for remote debugging over Tailscale via anyip.dev.
+// `<dashed-ip>.anyip.dev` resolves back to the embedded IP and anyip publishes a
+// real Let's Encrypt wildcard cert for `*.anyip.dev` (private key intentionally
+// public — same security as plain HTTP, which is fine since Tailscale already
+// encrypts the transport). Drop the cert into `.cert/anyip/` (git-ignored via
+// *.pem) and the dev server auto-serves HTTPS so secure-context APIs work:
+//   mkdir -p .cert/anyip
+//   curl -o .cert/anyip/fullchain.pem https://anyip.dev/cert/fullchain.pem
+//   curl -o .cert/anyip/privkey.pem   https://anyip.dev/cert/privkey.pem
+// Then open e.g. https://100-77-4-5.anyip.dev:4321 (your Tailscale IP, dashed).
+const anyipCert = "./.cert/anyip/fullchain.pem";
+const anyipKey = "./.cert/anyip/privkey.pem";
+const devHttps =
+  fs.existsSync(anyipCert) && fs.existsSync(anyipKey)
+    ? { cert: fs.readFileSync(anyipCert), key: fs.readFileSync(anyipKey) }
+    : undefined;
+
 // https://astro.build/config
 export default defineConfig({
   // adapter: vercel(),
+  // Dev/preview server — listen on all interfaces so it's reachable over
+  // Tailscale (MagicDNS host `*.hound-manta.ts.net`) for remote debugging.
+  // The leading dot in `allowedHosts` whitelists every machine in the tailnet.
+  server: {
+    host: true,
+    port: 4321,
+    allowedHosts: [".hound-manta.ts.net", ".anyip.dev"],
+  },
   build: {
     // https://docs.astro.build/zh-cn/reference/configuration-reference/#buildformat
     format: "preserve",
@@ -120,6 +145,12 @@ export default defineConfig({
       exclude: ["@resvg/resvg-js"],
     },
     plugins: [tailwindcss(), rawFonts([".ttf", ".woff"])],
+    // `devHttps` is undefined unless the anyip cert is present, so this is a
+    // no-op for normal local dev and only flips the dev server to HTTPS when
+    // you've downloaded the cert (see the note near the top of this file).
+    server: {
+      https: devHttps,
+    },
   },
   env: {
     schema: {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "cert:anyip": "curl -fsS --create-dirs -o .cert/anyip/fullchain.pem https://anyip.dev/cert/fullchain.pem && curl -fsS --create-dirs -o .cert/anyip/privkey.pem https://anyip.dev/cert/privkey.pem && echo 'anyip cert saved to .cert/anyip/ (run: pnpm dev for HTTPS)'",
     "build": "pnpm run build:site && pnpm run build:search",
     "build:site": "astro build",
     "build:debug": "cross-env NODE_OPTIONS=--trace-warnings pnpm run build:site",


### PR DESCRIPTION
## What

Make `pnpm dev` optionally serve **HTTPS** so the dev server is reachable from any device on the tailnet with a browser-trusted TLS cert — handy for mobile / secure-context debugging.

## How

- **`astro.config.ts`** — when an [anyip.dev](https://anyip.dev) wildcard cert is present in `.cert/anyip/`, the Vite dev server serves HTTPS **and** binds to all interfaces (`host: true`) so it's reachable over Tailscale. Without the cert it falls back to Astro's localhost-only default, so a plain `pnpm dev` is never exposed to the LAN. The cert read is wrapped in try/catch so a corrupt cert can't abort `pnpm build`.
- **`package.json`** — `pnpm cert:anyip` downloads the wildcard cert into `.cert/anyip/` (via `curl --create-dirs`).
- **`AGENTS.md`** — documents the Tailscale + anyip.dev workflow, the dashed-IP URL pattern, and the LAN-exposure caveat.

**Mechanism:** anyip's DNS resolves `<dashed-ip>.anyip.dev` back to the embedded IP, and it serves a real Let's Encrypt wildcard cert for `*.anyip.dev` whose private key is intentionally public (equivalent security to plain HTTP — fine because Tailscale already encrypts the transport). HMR works over the same port.

**On host allowlisting:** an earlier revision added `server.allowedHosts`, but Vite skips its host-header check entirely over HTTPS, so it was a no-op and has been removed. DNS-rebinding is instead mitigated by Vite's default CORS policy (only localhost origins may read responses) plus keeping the all-interfaces bind gated behind the HTTPS opt-in.

## Verification

Tested end-to-end locally:
- With cert → `https://100-77-4-5.anyip.dev:4321` → HTTP 200, system-CA-trusted cert.
- Without cert → server logs `Network: use --host to expose`; the Tailscale IP refuses connections (localhost-only).

## Notes

- Cert files live in `.cert/anyip/`, git-ignored via the existing `*.pem` rule; re-download ~every 90 days on expiry.
- **No production / deploy impact** — only affects local `astro dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
