### PR TITLE
🔧 chore(deps): bump pnpm pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.2.0",
   "license": "CC-BY-SA-4.0",
   "type": "module",
-  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
   "engines": {
     "node": ">=22.12.0",
     "pnpm": ">=11"


### PR DESCRIPTION
## Summary

- Bump `packageManager` to published `pnpm@11.5.2`.

## Notes

- No breaking-change migration expected; this is a package-manager patch release only.
- Verified `pnpm@11.5.2` is published on npm with a matching Corepack integrity pin.
- Astro-family latest releases remain deferred where they are outside the current wanted range or supply-chain age gate.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm outdated --format json`
- `pnpm run lint`
- `pnpm run build`
