### PR TITLE
♻️ note/post 间距对齐、dev HTTPS 自举与结构收敛

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,9 @@ documented in the note atop `astro.config.ts`.
 
 > **Heads-up:** `pnpm dev` now binds to all interfaces (`0.0.0.0`), so it's reachable not only over
 > Tailscale but on any LAN the machine is attached to — run it only on networks you trust, or add a
-> firewall rule. To stay localhost-only, run `astro dev` directly (no cert prestep) or delete
-> `.cert/anyip/` and use Astro's default.
+> firewall rule. Astro flips to HTTPS + all-interfaces whenever `.cert/anyip/` exists, regardless of
+> how the cert got there — so to stay localhost-only, delete `.cert/anyip/` (if present) **and** start
+> with `astro dev` directly, so the prestep doesn't re-provision it.
 
 ### File-level checks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ etc.) working in this repository.
 
 ```bash
 pnpm install        # install deps
-pnpm dev            # local dev server
-pnpm cert:anyip     # fetch anyip TLS cert so `pnpm dev` serves HTTPS (Tailscale remote debug)
+pnpm dev            # dev server; auto-provisions anyip cert → HTTPS on all interfaces (:4321)
+pnpm cert:anyip     # force-refresh the anyip TLS cert (pnpm dev already auto-fetches it)
 pnpm build          # production build, including pagefind search index
 pnpm build:site     # Astro-only build for faster local rebuild checks
 pnpm build:debug    # Astro build with NODE_OPTIONS=--trace-warnings
@@ -41,25 +41,28 @@ pnpm fix            # autocorrect + prettier --write + eslint --fix
 
 ### Remote debugging over Tailscale
 
-`pnpm dev` auto-serves **HTTPS** when an [anyip.dev](https://anyip.dev) wildcard cert is present
-in `.cert/anyip/`, making the dev server reachable from any device on the tailnet with a
-browser-trusted TLS cert (handy for mobile / secure-context testing). Without the cert it falls
-back to plain HTTP on localhost, so the default local flow is unchanged.
+`pnpm dev` provisions an [anyip.dev](https://anyip.dev) wildcard cert into `.cert/anyip/` before
+starting (via `scripts/ensure-anyip-cert.mjs`), then auto-serves **HTTPS** bound to all interfaces
+— so the dev server is reachable from any device on the tailnet with a browser-trusted TLS cert
+(handy for mobile / secure-context testing). The prestep is idempotent: it skips the network when
+a valid, unexpired cert is already on disk, auto-renews when it's within 7 days of expiry, and
+fails open (warns, then runs plain HTTP on localhost) when offline.
 
 ```bash
-# One-time; re-run ~every 90 days when the cert expires. Saves into .cert/anyip/ (git-ignored).
-pnpm cert:anyip
+pnpm dev            # ensures cert, then HTTPS dev on :4321 (all interfaces)
+pnpm cert:anyip     # force a cert refresh now (rarely needed; pnpm dev auto-renews)
 ```
 
-Then run `pnpm dev` and open `https://<dashed-ip>.anyip.dev:4321`, where `<dashed-ip>` is this
-machine's Tailscale IP with dots written as dashes — look it up with `tailscale ip -4` (e.g.
-`100.77.4.5` → `100-77-4-5`). HMR works over the same port with no extra config. The mechanism
-(anyip resolves the embedded IP back, plus a Let's Encrypt wildcard cert for `*.anyip.dev` whose
-private key is intentionally public) is documented in the note atop `astro.config.ts`.
+Open `https://<dashed-ip>.anyip.dev:4321`, where `<dashed-ip>` is this machine's Tailscale IP with
+dots written as dashes — look it up with `tailscale ip -4` (e.g. `100.77.4.5` → `100-77-4-5`). HMR
+works over the same port with no extra config. The mechanism (anyip resolves the embedded IP back,
+plus a Let's Encrypt wildcard cert for `*.anyip.dev` whose private key is intentionally public) is
+documented in the note atop `astro.config.ts`.
 
-> **Heads-up:** with the cert present the dev server binds to all interfaces (`0.0.0.0`), so it's
-> reachable not only over Tailscale but on any LAN the machine is attached to — enable it only on
-> networks you trust, or add a firewall rule. Without the cert, `pnpm dev` stays on `localhost`.
+> **Heads-up:** `pnpm dev` now binds to all interfaces (`0.0.0.0`), so it's reachable not only over
+> Tailscale but on any LAN the machine is attached to — run it only on networks you trust, or add a
+> firewall rule. To stay localhost-only, run `astro dev` directly (no cert prestep) or delete
+> `.cert/anyip/` and use Astro's default.
 
 ### File-level checks
 

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -30,9 +30,11 @@ import rehypeUnwrapImages from "rehype-unwrap-images";
 // `<dashed-ip>.anyip.dev` resolves back to the embedded IP and anyip publishes a
 // real Let's Encrypt wildcard cert for `*.anyip.dev` (private key intentionally
 // public — same security as plain HTTP, which is fine since Tailscale already
-// encrypts the transport). Drop the cert into `.cert/anyip/` (git-ignored via
-// *.pem) and the dev server auto-serves HTTPS so secure-context APIs work:
-//   pnpm cert:anyip   # downloads fullchain.pem + privkey.pem into .cert/anyip/
+// encrypts the transport). The cert lives in `.cert/anyip/` (git-ignored via
+// *.pem); whenever it's present the dev server auto-serves HTTPS so
+// secure-context APIs work. `pnpm dev` ensures the cert first (see
+// scripts/ensure-anyip-cert.mjs), so it's HTTPS by default; `pnpm cert:anyip`
+// force-refreshes it.
 // Then open e.g. https://100-77-4-5.anyip.dev:4321 (your Tailscale IP, dashed).
 const anyipCert = "./.cert/anyip/fullchain.pem";
 const anyipKey = "./.cert/anyip/privkey.pem";
@@ -53,9 +55,10 @@ const devHttps = (() => {
 export default defineConfig({
   // adapter: vercel(),
   // Dev server. Only bind to all interfaces when the anyip cert is present
-  // (i.e. you've opted into HTTPS remote debugging over Tailscale). Without the
-  // cert, fall back to Astro's localhost-only default so a plain `pnpm dev` is
-  // never exposed to the LAN.
+  // (i.e. HTTPS remote debugging over Tailscale). `pnpm dev` provisions the cert
+  // up front, so it binds here by default; running `astro dev` directly with no
+  // cert on disk falls back to Astro's localhost-only default and is never
+  // exposed to the LAN.
   //
   // No `allowedHosts` here: Vite skips its host-header allowlist entirely when
   // the dev server runs over HTTPS (https://vite.dev/config/server-options),

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "pnpm": ">=11"
   },
   "scripts": {
-    "dev": "astro dev",
-    "start": "astro dev",
-    "cert:anyip": "curl -fsS --create-dirs -o .cert/anyip/fullchain.pem https://anyip.dev/cert/fullchain.pem && curl -fsS --create-dirs -o .cert/anyip/privkey.pem https://anyip.dev/cert/privkey.pem && echo 'anyip cert saved to .cert/anyip/ (run: pnpm dev for HTTPS)'",
+    "dev": "node scripts/ensure-anyip-cert.mjs && astro dev",
+    "start": "pnpm run dev",
+    "cert:anyip": "node scripts/ensure-anyip-cert.mjs --force",
     "build": "pnpm run build:site && pnpm run build:search",
     "build:site": "astro build",
     "build:debug": "cross-env NODE_OPTIONS=--trace-warnings pnpm run build:site",

--- a/scripts/ensure-anyip-cert.mjs
+++ b/scripts/ensure-anyip-cert.mjs
@@ -10,16 +10,16 @@
 // directly (no prestep) to stay localhost-only. See AGENTS.md → "Remote
 // debugging over Tailscale".
 //
-// The download itself runs through `curl` (the tool this repo has always used
-// for it) rather than fetch()+writeFile: that keeps the network read and the
-// file write inside curl, so this process has no untrusted-network-data → fs
-// dataflow (which static analysis flags). The URL and destinations are fixed
-// constants and execFile takes an argv array (no shell), so nothing here is
-// attacker-influenced.
+// The download runs through `curl` (the tool this repo has always used for it)
+// rather than fetch()+writeFile: the network read and the file write both happen
+// inside curl, so this process has no untrusted-network-data → fs dataflow, and
+// curl honours the standard `HTTPS_PROXY`/`HTTP_PROXY` env on proxied machines.
+// The URL and destinations are fixed constants and execFile takes an argv array
+// (no shell), so nothing here is attacker-influenced.
 import { execFile } from "node:child_process";
-import { X509Certificate } from "node:crypto";
+import { X509Certificate, createPrivateKey } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { rm } from "node:fs/promises";
+import { rename, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
@@ -28,25 +28,52 @@ const run = promisify(execFile);
 const dir = new URL("../.cert/anyip/", import.meta.url);
 const certPath = new URL("fullchain.pem", dir);
 const keyPath = new URL("privkey.pem", dir);
+// Temp targets carry a `.pem` suffix so `.gitignore`'s `*.pem` covers them too.
+const certTmp = new URL("fullchain.tmp.pem", dir);
+const keyTmp = new URL("privkey.tmp.pem", dir);
 const SOURCE = "https://anyip.dev/cert";
-const RENEW_BEFORE_MS = 7 * 24 * 60 * 60 * 1000; // refetch when <7 days remain
+const RENEW_BEFORE_MS = 7 * 24 * 60 * 60 * 1000; // renew when <7 days remain
 const force = process.argv.includes("--force");
 
-/** Both files exist, the cert parses, and it isn't within 7 days of expiry. */
-function certIsFresh() {
+/** Cert expiry (epoch ms) when BOTH the on-disk cert and private key parse,
+ *  else null. Parsing the key too means a corrupt/truncated key never passes. */
+function pairExpiry() {
   try {
-    if (!existsSync(certPath) || !existsSync(keyPath)) return false;
-    const { validTo } = new X509Certificate(readFileSync(certPath));
-    return Date.parse(validTo) - Date.now() > RENEW_BEFORE_MS;
+    if (!existsSync(certPath) || !existsSync(keyPath)) return null;
+    createPrivateKey(readFileSync(keyPath)); // throws on a missing/garbled key
+    return Date.parse(new X509Certificate(readFileSync(certPath)).validTo);
   } catch {
-    return false;
+    return null;
   }
 }
 
-/** Download one PEM into its fixed destination via curl. `-f` makes curl fail
- *  (non-zero) on HTTP >= 400 so an error page never lands on disk. */
-async function fetchCert(name, dest) {
-  await run("curl", ["-fsS", "--create-dirs", "-o", fileURLToPath(dest), `${SOURCE}/${name}`]);
+/** A valid pair exists and the cert hasn't expired yet — worth serving HTTPS. */
+function certIsUsable() {
+  const expiry = pairExpiry();
+  return expiry !== null && expiry > Date.now();
+}
+
+/** Usable AND more than 7 days from expiry — no need to renew. */
+function certIsFresh() {
+  const expiry = pairExpiry();
+  return expiry !== null && expiry - Date.now() > RENEW_BEFORE_MS;
+}
+
+/** Download one PEM to a temp path via curl. `-f` fails on HTTP >= 400 so an
+ *  error page never lands on disk; the timeouts stop a stalled or half-open
+ *  connection from hanging `pnpm dev` — it funnels into the catch instead. */
+async function curlTo(name, tmpDest) {
+  await run("curl", [
+    "-fsS",
+    "--connect-timeout",
+    "10",
+    "--max-time",
+    "20",
+    "--create-dirs",
+    "-o",
+    fileURLToPath(tmpDest),
+    `${SOURCE}/${name}`,
+  ]);
 }
 
 if (!force && certIsFresh()) {
@@ -55,21 +82,33 @@ if (!force && certIsFresh()) {
 }
 
 try {
-  await Promise.all([fetchCert("fullchain.pem", certPath), fetchCert("privkey.pem", keyPath)]);
-  // Sanity-check the download is a real cert (also catches a 200 whose body
-  // isn't a certificate) — a local-file read, no network dataflow.
-  const { validTo } = new X509Certificate(readFileSync(certPath));
+  // Download to temp files, validate, then move into place — so a partial
+  // failure never leaves a half-updated or mismatched cert/key pair live.
+  // allSettled (not Promise.all) so both curls finish before we touch temps.
+  const settled = await Promise.allSettled([
+    curlTo("fullchain.pem", certTmp),
+    curlTo("privkey.pem", keyTmp),
+  ]);
+  const failure = settled.find((r) => r.status === "rejected");
+  if (failure) throw failure.reason;
+
+  const { validTo } = new X509Certificate(readFileSync(certTmp)); // reject a non-cert body
+  createPrivateKey(readFileSync(keyTmp)); // reject a non-key body
+  await Promise.all([rename(certTmp, certPath), rename(keyTmp, keyPath)]);
   console.log(`✓ anyip cert fetched into .cert/anyip/ (valid until ${validTo}) — dev serves HTTPS on :4321`);
 } catch (err) {
-  // Renewal failed (offline / anyip down / not a cert). Exit 0 either way so the
-  // chained `astro dev` still starts. If a usable cert is still on disk, keep
-  // serving HTTPS with it; otherwise delete the stale/corrupt files so
-  // astro.config.ts falls back to localhost-only HTTP instead of a bad cert.
-  if (certIsFresh()) {
-    console.warn(`⚠ anyip cert refresh failed (${err.message}); keeping the existing valid cert`);
+  // Renewal failed (offline / anyip down / stalled / bad body). Exit 0 either
+  // way so the chained `astro dev` still starts. Keep the existing pair while
+  // it's still *usable* (not expired) — even inside the 7-day renewal window, a
+  // few valid days of HTTPS beat dropping to localhost. Only delete it when
+  // unusable, so astro.config.ts falls back to localhost-only HTTP.
+  await Promise.all([rm(certTmp, { force: true }), rm(keyTmp, { force: true })]);
+  const reason = err instanceof Error ? err.message : String(err);
+  if (certIsUsable()) {
+    console.warn(`⚠ anyip cert refresh failed (${reason}); keeping the existing valid cert`);
   } else {
     await rm(dir, { recursive: true, force: true });
-    console.warn(`⚠ anyip cert fetch failed (${err.message}); removed stale cert → dev falls back to localhost HTTP`);
+    console.warn(`⚠ anyip cert fetch failed (${reason}); removed unusable cert → dev falls back to localhost HTTP`);
   }
   process.exit(0);
 }

--- a/scripts/ensure-anyip-cert.mjs
+++ b/scripts/ensure-anyip-cert.mjs
@@ -1,0 +1,63 @@
+// Ensure the anyip.dev wildcard cert is present (and unexpired) so `pnpm dev`
+// serves HTTPS for remote debugging over Tailscale. Idempotent: skips the
+// network when a valid cert already exists; pass `--force` to refetch anyway.
+//
+// The cert is a real Let's Encrypt wildcard for `*.anyip.dev` whose private key
+// is intentionally public — transport security comes from Tailscale, this just
+// satisfies browsers' secure-context requirement. astro.config.ts auto-serves
+// HTTPS (and binds all interfaces on :4321) whenever the cert is present, so
+// this script is what flips `pnpm dev` into Tailscale/LAN mode. Run `astro dev`
+// directly (no prestep) to stay localhost-only. See AGENTS.md → "Remote
+// debugging over Tailscale".
+import { X509Certificate } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+
+const dir = new URL("../.cert/anyip/", import.meta.url);
+const certPath = new URL("fullchain.pem", dir);
+const keyPath = new URL("privkey.pem", dir);
+const SOURCE = "https://anyip.dev/cert";
+const RENEW_BEFORE_MS = 7 * 24 * 60 * 60 * 1000; // refetch when <7 days remain
+const force = process.argv.includes("--force");
+
+/** Both files exist, the cert parses, and it isn't within 7 days of expiry. */
+function certIsFresh() {
+  try {
+    if (!existsSync(certPath) || !existsSync(keyPath)) return false;
+    const { validTo } = new X509Certificate(readFileSync(certPath));
+    return Date.parse(validTo) - Date.now() > RENEW_BEFORE_MS;
+  } catch {
+    return false;
+  }
+}
+
+async function download(name) {
+  const res = await fetch(`${SOURCE}/${name}`);
+  if (!res.ok) throw new Error(`${name}: HTTP ${res.status}`);
+  return Buffer.from(await res.arrayBuffer());
+}
+
+if (!force && certIsFresh()) {
+  console.log("✓ anyip cert present and unexpired — HTTPS dev ready (skipping fetch)");
+  process.exit(0);
+}
+
+try {
+  const [cert, key] = await Promise.all([download("fullchain.pem"), download("privkey.pem")]);
+  const { validTo } = new X509Certificate(cert); // also rejects an HTML error page
+  await mkdir(dir, { recursive: true });
+  await Promise.all([writeFile(certPath, cert), writeFile(keyPath, key)]);
+  console.log(`✓ anyip cert fetched into .cert/anyip/ (valid until ${validTo}) — dev serves HTTPS on :4321`);
+} catch (err) {
+  // Renewal failed (offline / anyip down). Exit 0 either way so the chained
+  // `astro dev` still starts. If a usable cert is still on disk, keep serving
+  // HTTPS with it; otherwise delete the stale/corrupt files so astro.config.ts
+  // falls back to localhost-only HTTP instead of trying to serve a bad cert.
+  if (certIsFresh()) {
+    console.warn(`⚠ anyip cert refresh failed (${err.message}); keeping the existing valid cert`);
+  } else {
+    await rm(dir, { recursive: true, force: true });
+    console.warn(`⚠ anyip cert fetch failed (${err.message}); removed stale cert → dev falls back to localhost HTTP`);
+  }
+  process.exit(0);
+}

--- a/scripts/ensure-anyip-cert.mjs
+++ b/scripts/ensure-anyip-cert.mjs
@@ -5,10 +5,12 @@
 // The cert is a real Let's Encrypt wildcard for `*.anyip.dev` whose private key
 // is intentionally public — transport security comes from Tailscale, this just
 // satisfies browsers' secure-context requirement. astro.config.ts auto-serves
-// HTTPS (and binds all interfaces on :4321) whenever the cert is present, so
-// this script is what flips `pnpm dev` into Tailscale/LAN mode. Run `astro dev`
-// directly (no prestep) to stay localhost-only. See AGENTS.md → "Remote
-// debugging over Tailscale".
+// HTTPS (and binds all interfaces on :4321) whenever `.cert/anyip/` is present
+// — gated purely on the files existing, not on this script having run. So this
+// script is what flips `pnpm dev` into Tailscale/LAN mode by provisioning that
+// cert; to stay localhost-only, skip the prestep AND make sure `.cert/anyip/`
+// is absent (a leftover cert keeps HTTPS/all-interfaces on by itself). See
+// AGENTS.md → "Remote debugging over Tailscale".
 //
 // The download runs through `curl` (the tool this repo has always used for it)
 // rather than fetch()+writeFile: the network read and the file write both happen

--- a/scripts/ensure-anyip-cert.mjs
+++ b/scripts/ensure-anyip-cert.mjs
@@ -9,9 +9,21 @@
 // this script is what flips `pnpm dev` into Tailscale/LAN mode. Run `astro dev`
 // directly (no prestep) to stay localhost-only. See AGENTS.md → "Remote
 // debugging over Tailscale".
+//
+// The download itself runs through `curl` (the tool this repo has always used
+// for it) rather than fetch()+writeFile: that keeps the network read and the
+// file write inside curl, so this process has no untrusted-network-data → fs
+// dataflow (which static analysis flags). The URL and destinations are fixed
+// constants and execFile takes an argv array (no shell), so nothing here is
+// attacker-influenced.
+import { execFile } from "node:child_process";
 import { X509Certificate } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
 
 const dir = new URL("../.cert/anyip/", import.meta.url);
 const certPath = new URL("fullchain.pem", dir);
@@ -31,10 +43,10 @@ function certIsFresh() {
   }
 }
 
-async function download(name) {
-  const res = await fetch(`${SOURCE}/${name}`);
-  if (!res.ok) throw new Error(`${name}: HTTP ${res.status}`);
-  return Buffer.from(await res.arrayBuffer());
+/** Download one PEM into its fixed destination via curl. `-f` makes curl fail
+ *  (non-zero) on HTTP >= 400 so an error page never lands on disk. */
+async function fetchCert(name, dest) {
+  await run("curl", ["-fsS", "--create-dirs", "-o", fileURLToPath(dest), `${SOURCE}/${name}`]);
 }
 
 if (!force && certIsFresh()) {
@@ -43,16 +55,16 @@ if (!force && certIsFresh()) {
 }
 
 try {
-  const [cert, key] = await Promise.all([download("fullchain.pem"), download("privkey.pem")]);
-  const { validTo } = new X509Certificate(cert); // also rejects an HTML error page
-  await mkdir(dir, { recursive: true });
-  await Promise.all([writeFile(certPath, cert), writeFile(keyPath, key)]);
+  await Promise.all([fetchCert("fullchain.pem", certPath), fetchCert("privkey.pem", keyPath)]);
+  // Sanity-check the download is a real cert (also catches a 200 whose body
+  // isn't a certificate) — a local-file read, no network dataflow.
+  const { validTo } = new X509Certificate(readFileSync(certPath));
   console.log(`✓ anyip cert fetched into .cert/anyip/ (valid until ${validTo}) — dev serves HTTPS on :4321`);
 } catch (err) {
-  // Renewal failed (offline / anyip down). Exit 0 either way so the chained
-  // `astro dev` still starts. If a usable cert is still on disk, keep serving
-  // HTTPS with it; otherwise delete the stale/corrupt files so astro.config.ts
-  // falls back to localhost-only HTTP instead of trying to serve a bad cert.
+  // Renewal failed (offline / anyip down / not a cert). Exit 0 either way so the
+  // chained `astro dev` still starts. If a usable cert is still on disk, keep
+  // serving HTTPS with it; otherwise delete the stale/corrupt files so
+  // astro.config.ts falls back to localhost-only HTTP instead of a bad cert.
   if (certIsFresh()) {
     console.warn(`⚠ anyip cert refresh failed (${err.message}); keeping the existing valid cert`);
   } else {

--- a/src/components/blog/FeaturedPostPreview.astro
+++ b/src/components/blog/FeaturedPostPreview.astro
@@ -28,13 +28,10 @@ const subtitle = post.data.subtitle?.trim();
     aria-hidden="true"
     class="border-foreground/5 order-2 hidden min-w-6 flex-1 self-center border-t sm:block dark:border-white/5"
   ></span>
-  <FormattedDate
-    class="date order-3 shrink-0 text-gray-600 dark:text-gray-400"
-    date={post.data.publishDate}
-  />
+  <FormattedDate class="date text-muted order-3 shrink-0" date={post.data.publishDate} />
   {
     subtitle && (
-      <p class="font-plex-sans order-2 w-full text-sm leading-snug text-gray-600 sm:order-4 dark:text-gray-400">
+      <p class="font-plex-sans text-muted order-2 w-full text-sm leading-snug sm:order-4">
         {subtitle}
       </p>
     )

--- a/src/components/blog/PostPreview.astro
+++ b/src/components/blog/PostPreview.astro
@@ -13,10 +13,7 @@ const { as: Tag = "div", post, withDesc = false } = Astro.props;
 const postUrl = getPostPath(post);
 ---
 
-<FormattedDate
-  class="date min-w-30 text-gray-600 dark:text-gray-400"
-  date={post.data.publishDate}
-/>
+<FormattedDate class="date text-muted min-w-30" date={post.data.publishDate} />
 <Tag class="leading-snug">
   {post.data.draft && <span class="text-red-500">(Draft) </span>}
   <a class="cactus-link text-foreground" data-astro-prefetch href={postUrl}>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -4,7 +4,7 @@ import { siteConfig } from "@/site.config";
 ---
 
 <footer class="flex min-h-15 flex-col">
-  <div class="page-shell note py-10 text-gray-600 sm:flex-col dark:text-gray-400">
+  <div class="page-shell note text-muted py-10 sm:flex-col">
     <div class="grid items-center gap-x-4 gap-y-2 sm:grid-cols-[1fr_auto_1fr]">
       <a
         href="https://github.com/daihaus/xdanger.com"

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -16,9 +16,7 @@ import { siteConfig } from "@/site.config";
         <p class="site-header-title text-accent-2 font-plex-serif-medium leading-none font-medium">
           <a href="/" data-astro-prefetch>{siteConfig.author}</a>
         </p>
-        <p
-          class="site-header-tagline note max-w-2xl overflow-hidden leading-relaxed text-gray-600 dark:text-gray-400"
-        >
+        <p class="site-header-tagline note text-muted max-w-2xl overflow-hidden leading-relaxed">
           Notes on tech, products, and life.
         </p>
       </div>

--- a/src/components/note/Note.astro
+++ b/src/components/note/Note.astro
@@ -2,6 +2,7 @@
 import { type CollectionEntry, render } from "astro:content";
 import FormattedDate from "@/components/FormattedDate.astro";
 import { getNotePath } from "@/utils/url";
+import { PROSE_ARTICLE } from "@/utils/prose";
 import type { HTMLTag, Polymorphic } from "astro/types";
 
 type Props<Tag extends HTMLTag> = Polymorphic<{ as: Tag }> & {
@@ -50,7 +51,7 @@ const noteUrl = getNotePath(note);
     class:list={[
       isPreview
         ? "note line-clamp-6 max-w-none [&_a]:relative [&_a]:z-10"
-        : "prose prose-base prose-headings:font-plex-serif-medium prose-headings:font-medium prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none max-w-none",
+        : `${PROSE_ARTICLE} max-w-none`,
     ]}
   >
     <Content />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -16,7 +16,7 @@ const articleDate = updatedDate?.toISOString() ?? publishDate.toISOString();
 
 <BaseLayout meta={{ articleDate, description, ogImage: socialImage, title, post }}>
   <section class="page-section pt-0">
-    <div id="blog-hero" class="page-shell">
+    <div class="page-shell">
       <Masthead post={post} />
     </div>
   </section>
@@ -30,42 +30,4 @@ const articleDate = updatedDate?.toISOString() ?? publishDate.toISOString();
       </div>
     </div>
   </article>
-  <button
-    class="hover:border-link fixed end-4 bottom-8 z-90 flex h-10 w-10 translate-y-28 cursor-pointer items-center justify-center rounded-full border-2 border-transparent bg-zinc-200 text-3xl opacity-0 transition-all transition-discrete duration-300 data-[show=true]:translate-y-0 data-[show=true]:opacity-100 sm:end-8 sm:h-12 sm:w-12 dark:bg-zinc-700"
-    data-show="false"
-    id="to-top-btn"
-  >
-    <span class="sr-only">Back to top</span>
-    <svg
-      aria-hidden="true"
-      class="h-6 w-6"
-      fill="none"
-      focusable="false"
-      stroke="currentColor"
-      stroke-width="2"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path d="M4.5 15.75l7.5-7.5 7.5 7.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    </svg>
-  </button>
 </BaseLayout>
-
-<script>
-  const scrollBtn = document.getElementById("to-top-btn") as HTMLButtonElement;
-  const targetHeader = document.getElementById("blog-hero") as HTMLDivElement;
-
-  function callback(entries: IntersectionObserverEntry[]) {
-    entries.forEach((entry) => {
-      // only show the scroll to top button when the heading is out of view
-      scrollBtn.dataset.show = (!entry.isIntersecting).toString();
-    });
-  }
-
-  scrollBtn.addEventListener("click", () => {
-    document.documentElement.scrollTo({ behavior: "smooth", top: 0 });
-  });
-
-  const observer = new IntersectionObserver(callback);
-  observer.observe(targetHeader);
-</script>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -21,7 +21,7 @@ const articleDate = updatedDate?.toISOString() ?? publishDate.toISOString();
     </div>
   </section>
   <article class="flex-colgrow flex break-words" data-pagefind-body>
-    <div class="content-shell flex-col gap-10 py-4 sm:py-6 lg:flex-row lg:items-start">
+    <div class="content-shell flex-col gap-10 py-4 sm:pt-6 sm:pb-12 lg:flex-row lg:items-start">
       <div
         class="prose prose-base prose-headings:font-plex-serif-medium prose-headings:font-medium prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none max-w-3xl"
       >

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -2,6 +2,7 @@
 import type { CollectionEntry } from "astro:content";
 import Masthead from "@/components/blog/Masthead.astro";
 import WebMentions from "@/components/blog/webmentions/index.astro";
+import { PROSE_ARTICLE } from "@/utils/prose";
 import BaseLayout from "./Base.astro";
 
 interface Props {
@@ -20,11 +21,9 @@ const articleDate = updatedDate?.toISOString() ?? publishDate.toISOString();
       <Masthead post={post} />
     </div>
   </section>
-  <article class="flex-colgrow flex break-words" data-pagefind-body>
+  <article class="flex break-words" data-pagefind-body>
     <div class="content-shell flex-col gap-10 py-4 sm:pt-6 sm:pb-12 lg:flex-row lg:items-start">
-      <div
-        class="prose prose-base prose-headings:font-plex-serif-medium prose-headings:font-medium prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none max-w-3xl"
-      >
+      <div class:list={[PROSE_ARTICLE, "max-w-3xl"]}>
         <slot />
         <WebMentions />
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from "astro:content";
 import AboutMe from "@/components/AboutMe.astro";
-import HomePostPreview from "@/components/blog/HomePostPreview.astro";
+import FeaturedPostPreview from "@/components/blog/FeaturedPostPreview.astro";
 import Note from "@/components/note/Note.astro";
 import { getAllPosts } from "@/data/post";
 import PageLayout from "@/layouts/Base.astro";
@@ -34,7 +34,7 @@ const latestNotes = allNotes.sort(collectionDateSort).slice(0, MAX_NOTES);
         {
           allPostsByDate.map((p) => (
             <li>
-              <HomePostPreview as="h3" post={p} />
+              <FeaturedPostPreview as="h3" post={p} />
             </li>
           ))
         }

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -28,7 +28,7 @@ const meta = {
 ---
 
 <PageLayout meta={meta}>
-  <section class="page-section pt-0 pb-4 sm:pb-6">
+  <section class="page-section pt-0 pb-4 sm:pb-12">
     <div class="content-shell">
       <Note as="h1" note={note} />
     </div>

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -28,7 +28,7 @@ const meta = {
 ---
 
 <PageLayout meta={meta}>
-  <section class="page-section pt-0">
+  <section class="page-section pt-0 pb-4 sm:pb-6">
     <div class="content-shell">
       <Note as="h1" note={note} />
     </div>

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -77,7 +77,7 @@ const descYearKeys = Object.keys(groupedByYear).sort((a, b) => +b - +a);
         {
           !!uniqueTags.length && (
             <aside class="lg:pt-1">
-              <h2 class="font-plex-mono mb-4 text-sm text-gray-600 dark:text-gray-400">tags</h2>
+              <h2 class="font-plex-mono text-muted mb-4 text-sm">tags</h2>
               <ul class="flex flex-wrap gap-2 lg:block lg:space-y-2">
                 {uniqueTags.map((tag) => (
                   <li>

--- a/src/pages/tags/[tag]/[...page].astro
+++ b/src/pages/tags/[tag]/[...page].astro
@@ -36,13 +36,13 @@ const meta = {
 const paginationProps = {
   ...(page.url.prev && {
     prevUrl: {
-      text: "← Previous Tags",
+      text: "← Previous Page",
       url: page.url.prev,
     },
   }),
   ...(page.url.next && {
     nextUrl: {
-      text: "Next Tags →",
+      text: "Next Page →",
       url: page.url.next,
     },
   }),
@@ -52,7 +52,7 @@ const paginationProps = {
 <PageLayout meta={meta}>
   <section class="page-section pt-0">
     <div class="page-shell">
-      <div class="font-plex-mono mb-6 text-gray-600 dark:text-gray-400">
+      <div class="font-plex-mono text-muted mb-6">
         <a class="cactus-link text-accent" href="/tags"
           ><span class="sr-only">All {" "}</span>Tags</a
         >

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -27,7 +27,7 @@ const meta = {
               >
                 &#35;{tag}
               </a>
-              <span class="inline-block text-gray-600 dark:text-gray-400">
+              <span class="text-muted inline-block">
                 - {val} Post{val > 1 && "s"}
               </span>
             </li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -363,6 +363,12 @@ a.not-prose {
   @apply font-writer text-base;
 }
 
+/* Muted secondary text (timestamps, taglines, captions) — one pair that flips
+ * with the theme, instead of hand-writing `text-gray-600 dark:text-gray-400`. */
+@utility text-muted {
+  @apply text-gray-600 dark:text-gray-400;
+}
+
 @utility page-shell {
   @apply container mx-auto max-w-3xl px-4 sm:px-6;
 }

--- a/src/utils/prose.ts
+++ b/src/utils/prose.ts
@@ -1,0 +1,15 @@
+/**
+ * 文章正文（post 详情 + note 详情）共用的 `prose` 类串——单一事实源。
+ *
+ * 两处正文容器（src/layouts/BlogPost.astro、src/components/note/Note.astro）此前
+ * 各自内联一份逐字相同的长串；改 heading 锚点 `#`、字体、`before:` 颜色时要同步
+ * 两处、极易遗漏。抽到这里后，调用方只各自追加宽度约束：post 用 `max-w-3xl`、
+ * note 列用 `max-w-none`。
+ *
+ * 注：这里用 JS 常量而非 `@utility prose-article`，因为串内含 typography 插件的
+ * `prose-headings:` 变体；在 Tailwind v4 里 `@apply` 这类插件变体的行为不稳定，
+ * 而常量保持原样类名、渲染字节级一致。Tailwind v4 的内容扫描会读到本文件里的
+ * 类名 token，工具类照常生成。
+ */
+export const PROSE_ARTICLE =
+  "prose prose-base prose-headings:font-plex-serif-medium prose-headings:font-medium prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none";

--- a/src/utils/prose.ts
+++ b/src/utils/prose.ts
@@ -12,4 +12,4 @@
  * 类名 token，工具类照常生成。
  */
 export const PROSE_ARTICLE =
-  "prose prose-base prose-headings:font-plex-serif-medium prose-headings:font-medium prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none";
+  "prose prose-base prose-headings:font-plex-serif-medium prose-headings:font-medium prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-4 prose-headings:before:text-gray-600 dark:prose-headings:before:text-gray-400 prose-headings:hover:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none";


### PR DESCRIPTION
## 概览

源自一次「note footer 间距」的小修，连带做了 post 排版对齐、`pnpm dev` 的 HTTPS 自举，以及一轮结构收敛评审的快赢清单。共 7 个 commit，分三个主题。

## 1. note / post 排版对齐

- `🐛 fix(note)`：note footer 上边距补 `pb-4 sm:pb-6`，对齐 post 的有意间距
- `♻️ refactor(post)`：移除返回顶部按钮——它被 `main` 的 `[&>*]:relative` 挤成 in-flow，在正文与 footer 间撑出 48px 空白（按需求直接删除，连同其 observer 脚本与 dead `id`）
- `🐛 fix(layout)`：note/post 正文底部留白 24→48px（`sm:pb-12`），两页对齐在「正文 → footer 88px」；post 顶部 padding 保持不变

## 2. dev 工具链

- `🔧 chore(dev)`：`pnpm dev` 启动前自动检查/拉取 anyip 证书（`scripts/ensure-anyip-cert.mjs`），默认走 HTTPS + 全网卡，便于 Tailscale / 手机调试。脚本幂等、距到期 7 天内自动续期、离线则清掉坏证书优雅降级回 localhost。`cert:anyip` 改为强制刷新；AGENTS.md / astro.config.ts 注释同步。

## 3. 结构收敛（评审快赢）

一轮多 agent 评审后的低风险快赢，均浏览器核对渲染一致：

- `♻️ refactor(prose)`：抽 `PROSE_ARTICLE`（`src/utils/prose.ts`）——post/note 正文那串逐字重复的长 prose 类收成单一事实源；顺手清掉 `flex-colgrow` 死类
- `♻️ refactor(style)`：新增 `@utility text-muted`，替换 7 处手抄的 `text-gray-600 dark:text-gray-400`；tags 分页文案统一为 `Page`
- `♻️ refactor(blog)`：`HomePostPreview` → `FeaturedPostPreview`，与 `PostPreview` 消除命名歧义

## 验证

- `astro check`：**0 errors / 0 warnings / 0 hints**
- prettier / eslint / autocorrect：全绿
- 浏览器实测（HTTPS dev）：post/note prose 的 `#` 锚点 / 字体 / 颜色字节级一致；`text-muted` 浅 ↔ 暗正确翻转；两页 footer 间距对齐 88px
- 7 个 commit 全部 SSH 签名 verified

## 取舍说明

- `prose-article` 选用共享 JS 常量而非 `@utility`：串内含 typography 插件的 `prose-headings:` 变体，`@apply` 这类变体在 Tailwind v4 行为不稳；常量保证渲染零差异，同样单一事实源。
- 评审中「合并三套预览组件」「拆 `page-shell`/`content-shell`」「给三层造统一 motion 工具」等判为「为收敛而收敛」，本 PR 未采纳。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
