### PR TITLE
🔧 chore(domain)!: canonical 切到 apex xdanger.com

### DIFF
--- a/.claude/commands/note-from-issue.md
+++ b/.claude/commands/note-from-issue.md
@@ -39,7 +39,7 @@ argument-hint: "(无参数；配合 /loop 5m /note-from-issue 使用)"
 3. **无人值守**：没人会即时回你。**绝不 `AskUserQuestion`、绝不停下等人**，一切当场依现场
    （git / 构建 / 评审 / 标签 / PR 状态）自主决策。**卡住 ≠ 问人**：清理现场 → 打 `note-blocked`
    → 📣 通知 → 进下一个 issue。
-4. **全绿才合并**（合并即触发 deploy、note 直接上线 www.xdanger.com，近乎不可逆）。门禁不满足
+4. **全绿才合并**（合并即触发 deploy、note 直接上线 xdanger.com，近乎不可逆）。门禁不满足
    绝不强合。
 5. **幂等**：用 label 标在途，崩溃/中断后下一轮能续跑、不重复建 PR；卡住的停在 `note-blocked`
    不被反复重试。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,9 +216,11 @@ Conventional Commits + Gitmoji:
 ## Deployment
 
 GitHub Actions (`.github/workflows/deploy.yml`) builds via `withastro/action@v3` (which
-auto-detects pnpm from the lockfile) and deploys to GitHub Pages. Vercel is configured via
-`vercel.json` for the canonical site at `xdanger.com` (see `src/site.config.ts`; the `www`
-subdomain redirects to the apex `xdanger.com`).
+auto-detects pnpm from the lockfile) and deploys to GitHub Pages. The canonical host is the apex
+`xdanger.com`: the base URL lives in `src/site.config.ts` (`url`) and feeds `astro.config.ts`
+(`site:`), which drives the generated canonical/OG/RSS/sitemap URLs. `vercel.json` only configures
+`cleanUrls` and page-level redirects — the `www` → apex host redirect is set in Vercel's domain
+settings, not in `vercel.json`.
 
 ## Automation: issue → note
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,8 +217,8 @@ Conventional Commits + Gitmoji:
 
 GitHub Actions (`.github/workflows/deploy.yml`) builds via `withastro/action@v3` (which
 auto-detects pnpm from the lockfile) and deploys to GitHub Pages. Vercel is configured via
-`vercel.json` for the canonical site at `www.xdanger.com` (see `src/site.config.ts`; the apex
-`xdanger.com` redirects to `www`).
+`vercel.json` for the canonical site at `xdanger.com` (see `src/site.config.ts`; the `www`
+subdomain redirects to the apex `xdanger.com`).
 
 ## Automation: issue → note
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xdanger.com
 
-这是 [xdanger.com](https://www.xdanger.com/) 个人博客网站的源代码仓库，使用 [Astro](https://astro.build/) 框架构建。
+这是 [xdanger.com](https://xdanger.com/) 个人博客网站的源代码仓库，使用 [Astro](https://astro.build/) 框架构建。
 
 > AI agents (Claude Code, Codex, Cursor 等) 请阅读 [`AGENTS.md`](./AGENTS.md) 获取项目规范。
 

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-www.xdanger.com
+xdanger.com

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -22,7 +22,7 @@ export const siteConfig: SiteConfig = {
   // Used to construct the meta title property found in src/components/BaseHead.astro L:11, and webmanifest name found in astro.config.ts L:42
   title: "Kros Dai",
   // ! Please remember to replace the following site property with your own domain, used in astro.config.ts
-  url: "https://www.xdanger.com/",
+  url: "https://xdanger.com/",
 };
 
 // https://expressive-code.com/reference/configuration/


### PR DESCRIPTION
## 背景

canonical 域名从 `www.xdanger.com` 切换为 apex `xdanger.com`。本 PR 更新全站相关的**配置与文档**，历史文章（`_posts/`、`_notes/`）保持原样不动。

## 改动

| 文件 | 改动 |
|---|---|
| `src/site.config.ts` | `url` → `https://xdanger.com/`（驱动 canonical · og:url · RSS · sitemap · OG 图） |
| `public/CNAME` | `xdanger.com`（GitHub Pages 自定义域名） |
| `AGENTS.md` | Deployment 段：canonical 站点改为 `xdanger.com`，重定向方向反转为 `www`→apex |
| `README.md` | 顶部链接 → `https://xdanger.com/` |
| `.claude/commands/note-from-issue.md` | 「note 直接上线 xdanger.com」文案同步 |

## 验证

- `pnpm build:site` 通过（1115 页）
- 构建产物核验：`rel="canonical"`、`og:url`、`sitemap-index.xml`、`robots.txt` 均输出 apex `https://xdanger.com`
- 非历史文件中已无 `www.xdanger.com` 残留

## 仓库外的配套操作（已完成）

Vercel 后台域名重定向方向已由仓库所有者切换为 `www.xdanger.com` → apex `xdanger.com`（主机级重定向非仓库可配置项）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
