### PR TITLE
🔧 chore(deps): bump pnpm to 11.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.2.0",
   "license": "CC-BY-SA-4.0",
   "type": "module",
-  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
+  "packageManager": "pnpm@11.5.3+sha512.7ac1c919341c213a34dc0d02afb7143c5c26ac26ee8c4782deea821b8ac64d2134a081fd8941dae6e29bbb48f58dfc2b7fbceeccc07cb2f09d219d342a4969ed",
   "engines": {
     "node": ">=22.12.0",
     "pnpm": ">=11"


### PR DESCRIPTION
Updates the Corepack package manager pin from pnpm 11.5.2 to 11.5.3.

Validation:
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm outdated --format json

No dependency ranges were widened; existing wanted=current drift was left untouched.