### PR TITLE
🔧 chore(deps): bump `pnpm` to 11.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.2.0",
   "license": "CC-BY-SA-4.0",
   "type": "module",
-  "packageManager": "pnpm@11.5.3+sha512.7ac1c919341c213a34dc0d02afb7143c5c26ac26ee8c4782deea821b8ac64d2134a081fd8941dae6e29bbb48f58dfc2b7fbceeccc07cb2f09d219d342a4969ed",
+  "packageManager": "pnpm@11.6.0+sha512.9a36518224080c6fe5165afdcfe79bfa118c29be703f3f462b1e32efe1e98e47e8750b148e08286250aad4113cc7993ca413c4e2cd447752708c2ee5751bc95f",
   "engines": {
     "node": ">=22.12.0",
     "pnpm": ">=11"


### PR DESCRIPTION
## Summary
- bump the root packageManager pin from pnpm 11.5.3 to pnpm 11.6.0
- keep dependency ranges and lockfiles unchanged

## Validation
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm outdated --format json

Registry metadata: pnpm@11.6.0 is published with sha512 integrity `sha512-mjZRgiQIDG/lFlr9z+eb+hGMKb5wPz9GKx4y7+HpjkfodQsUjggoYlCq1BE8x5k8pBPE4s1Ed1JwjC7ldRvJXw==`.