### PR TITLE
✨ feat: re-anchor /note-from-issue writing on deep-dive + storytelling

### DIFF
--- a/.agents/skills/audience-aware-comms/SKILL.md
+++ b/.agents/skills/audience-aware-comms/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: audience-aware-comms
+description: >-
+  Apply whenever you are about to produce written output that an INTERPRETING
+  READER — a human, or another AI agent that will act on your words — will read
+  and act on: emails, IM/Slack, PR or issue descriptions, review comments,
+  design or decision docs, customer-facing copy, AND natural-language task
+  specs, prompts, or agent mandates whose executor is a person or an LLM. Use
+  it even when the user did not ask for "communication" and the message is only
+  a sub-step of a larger task (e.g. the PR body after a feature, or a prompt you
+  are writing for a downstream agent) — those incidental cases are where
+  audience-blind writing slips through, so reach for this proactively. It makes
+  you model the reader's actual capability and what they will infer or assume,
+  then emit only the calibrated artifact. Do NOT use for output consumed
+  literally by a deterministic interpreter — executed code, configs, schemas,
+  queries, regexes, test fixtures — where correctness is binary and there is no
+  mind to model.
+---
+
+# Audience-Aware Communication
+
+The "when to use" lives entirely in the `description` above — that is the trigger.
+By the time you are reading this body, assume the output has an interpreting reader
+and is consequential. (If on reflection it is consumed literally by a deterministic
+interpreter — executed code, a config, a schema, a query — exit quietly and respond
+normally; that is the one reader you do not model.)
+
+## Why this skill exists
+
+Writing lands well only when it fits the reader. There are two failure modes, mirror
+images of each other, and both come from ignoring the reader's actual level:
+
+- **To a human**, the default slip is _under_-modeling — writing for a literal
+  token-absorber: too blunt, missing what they will infer, ignoring what is better
+  left unsaid.
+- **To an AI executor**, the default slip is the opposite, _over_-specifying —
+  treating a capable reasoner like a level-0 machine, spelling out every mechanical
+  step. That buries the intent, wastes context, and actively suppresses the model's
+  judgment. (Write to it like it's an idiot and it will execute like one.)
+
+Same root error both times: not modeling the reader's real capability. A deterministic
+interpreter genuinely is literal — that is the only reader you skip. Everything else,
+human or LLM, infers and fills gaps, so model it.
+
+## 1. Run this in your thinking — never in the output
+
+1. **Model the reader** (human or AI): who they are · their actual capability /
+   expertise · what they know vs. don't · what they care about · the one action or
+   decision you want. Use only context already in hand. If it is thin, see section 4.
+2. **Climb the ladder** (this is k-level reasoning; do as many layers as the stakes
+   justify):
+   - **L1** — what they take from a literal read.
+   - **L2** — what they _infer_ about your intent, the situation, or the task from
+     _how_ it is written and from what you leave out.
+   - **L3** (high stakes only) — they expect you to be anticipating their reaction
+     or their gaps; does that recursion change the move?
+3. **Decide what to leave unsaid.** Omission is a tool, not a gap. Don't state what
+   they can infer; don't over-justify; don't surface what creates obligation, anxiety,
+   or constraint without purpose. Note which omissions are load-bearing.
+4. **Calibrate register and grain** to the reader and channel.
+
+## 1a. If the reader is an AI agent
+
+When the executor is another LLM (a downstream agent, a subagent, a prompt or mandate
+you are authoring), keep the ladder but change _what_ you model:
+
+- **Capability, not feelings.** Estimate its real level. Frontier agents reason well;
+  they need a clear target, not rote steps. There is no face to protect, so omission
+  here is about granting latitude, not tact.
+- **Specify the WHAT, trust the HOW.** Pin down precisely the things that are genuinely
+  underdetermined and costly to get wrong — the goal, hard constraints, interfaces and
+  contracts, acceptance criteria, and any ambiguity where a wrong guess is expensive.
+  Leave the method, the obvious sub-steps, and anything a capable reasoner infers from
+  the goal to the executor. This is delegating to a senior engineer, not micromanaging.
+- **Model where it will guess wrong.** Under-specifying is not a virtue either — a
+  context-free executor fills blanks with assumptions. Spend your words exactly on the
+  blanks that matter, not on the steps it already knows.
+
+## 2. Output rules
+
+- Emit **only the finished artifact.** Don't show the reader-analysis, the L1/L2/L3
+  ladder, or meta-phrases like "considering what they think I think." The reasoning
+  stays backstage; surfacing it breaks the effect and reads as odd.
+- Ship the **leanest version that achieves the goal.** Cut what the reader can infer;
+  for an AI executor, cut the mechanical steps it does not need spelled out.
+- **No manipulation, no false claims.** Audience-modeling is for clarity, tact, and
+  calibration — not for steering a reader against their own interest. Copy that schemes
+  reads as oily; this also keeps the prose clean and trustworthy.
+
+## 3. Self-check — high stakes only
+
+If the reader is **human**: cold-read the draft as the recipient seeing it for the first
+time — first reaction? unintended subtext? anywhere they'd bristle, feel condescended to,
+or feel rushed?
+
+If the reader is an **AI executor**: ask instead — where would a capable but context-free
+agent guess wrong, over-comply, or lose the goal under all this detail? Cut the
+over-specification; sharpen the genuinely ambiguous parts.
+
+Either way, revise once, then stop.
+
+## 4. When to ask instead of guessing
+
+If you lack the context to model the reader (unknown recipient, unclear stakes), ask for
+a one-line reader card rather than fabricating one:
+
+```
+Audience · reads how (skim / close / executes literally) · capability ·
+knows · doesn't · cares about · desired action · leave unsaid
+```
+
+For recurring recipients, keep profiles in `references/audience-profiles.md` and read
+that file only when a matching recipient comes up — it costs no context until then.
+
+## 5. What good looks like
+
+**Example 1 — PR description (embedded case, written after a hotfix).**
+The fix also quietly works around a flaky upstream API.
+
+- Weak (literal dump): "Fixed the crash. Not sure why the upstream API keeps timing out,
+  maybe their load balancer?" — broadcasts live doubt, invites bikeshedding, makes a fast
+  merge feel risky.
+- Strong (audience-aware): states what changed and why it's safe to merge now; the
+  flakiness becomes a linked follow-up issue, not aired uncertainty. Backstage: the
+  reviewer's only real question is "can I approve this quickly?"
+
+**Example 2 — message to a senior advisor billed by the hour; you need a decision Friday.**
+
+- Weak: "Can you confirm by Friday? We're waiting on you." — reads as chasing someone you
+  can't actually rush.
+- Strong: frame Friday as _your_ downstream constraint, give an easy path to respond, and
+  leave "we've already consulted another firm" unsaid — that omission is load-bearing.
+
+**Example 3 — a task prompt you are writing for a downstream coding agent.**
+
+- Weak (over-specified, treats it as level-0): a 20-step checklist — "open the file, find
+  the function, add a parameter, save, run the tests, if they fail read the error..." —
+  buries the goal and boxes in a capable model.
+- Strong (WHAT + constraints + acceptance, trust the HOW): "Add optional rate-limiting to
+  the `/charge` client. Constraint: do not change the public signature. Done when: existing
+  tests pass and a new test covers the limit being hit. Method is your call." Judgment is
+  invited, not replaced.
+
+The common thread: model the reader's real level, spend words where they change the
+outcome, and let the reasoning stay backstage. The reader — person or agent — sees only a
+clean artifact that happens to land right.

--- a/.agents/skills/audience-aware-comms/references/audience-profiles.md
+++ b/.agents/skills/audience-aware-comms/references/audience-profiles.md
@@ -1,0 +1,53 @@
+# Audience Profiles
+
+Reusable reader cards for recipients you write to often. The skill reads this
+file only when a recipient here matches the task, so it costs no context the rest
+of the time. One profile per recipient; keep each to the card format.
+
+> Keep this list to roles and durable communication preferences. Do not store
+> sensitive personal data here.
+
+## Template
+
+```
+### <handle or role>
+Reads how: <skims 30s / reads closely / reads on mobile>
+Knows: <what they already have context on>
+Doesn't: <what must be spelled out>
+Cares about: <the axis they judge on — risk, cost, speed, correctness, optics>
+Sensitive to: <being rushed, being over-explained to, surprises, scope creep>
+Default register: <terse / formal / warm / direct>
+Leave unsaid by default: <recurring load-bearing omissions>
+```
+
+## Profiles
+
+### code-reviewer (default)
+
+Reads how: skims first, reads diff closely if the summary earns it
+Knows: the codebase and conventions
+Doesn't: your debugging journey, dead ends you already ruled out
+Cares about: is this safe and correct to merge, and how fast can I approve it
+Sensitive to: aired uncertainty, walls of text, unscoped changes
+Default register: terse, factual
+Leave unsaid by default: speculation about causes you've already mitigated
+
+### external-advisor (billed hourly)
+
+Reads how: reads closely; time is literally money
+Knows: the engagement's background
+Doesn't: internal deliberations unless relevant to their advice
+Cares about: a crisp question with a clear decision boundary
+Sensitive to: being chased, vague asks that burn billable time
+Default register: formal, respectful, brief
+Leave unsaid by default: parallel options you're weighing elsewhere
+
+### first-time 科普 reader (published note)
+
+Reads how: skims on mobile first; reads closely only if the opening earns it
+Knows: smart and curious, but a first-time, non-specialist reader of this topic
+Doesn't: the jargon, the prerequisites, why this matters to them — assume none of it
+Cares about: "why should I care" and "will I actually understand this" — being let in, not impressed
+Sensitive to: jargon dumps, undefined acronyms, being talked down to, walls of unbroken text, manufactured drama
+Default register: clear and confident; one idea per sentence; warm but not chatty
+Leave unsaid by default: the research journey, hedging, meta-notes (（已校正）/（待核实）), "hope this helps" closers

--- a/.agents/skills/deep-dive/SKILL.md
+++ b/.agents/skills/deep-dive/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: deep-dive
+description: Structured pedagogical deep-dive for new substantive topics across STEM, technical/engineering practice, and humanities/business/history. Use this skill whenever the user asks to learn, understand, deep-dive, explore, or be taught a new concept they don't already have a working model of — including phrasings like "what is X", "how does Y work", "why does Z happen", "explain W", "带我入门 X", "讲讲 X", "教我 X", "我想搞懂 X", even when they don't use the word "teach" or "learn". Trigger especially when the topic is a named concept, framework, theorem, mechanism, technology, historical event, or intellectual movement. Do NOT trigger for quick factual lookups ("when did X happen"), tool/syntax questions ("how do I curl with auth"), conversational chitchat, or mid-flow technical discussion where the user is already engaged on the topic.
+---
+
+# Deep-Dive Skill
+
+This skill turns an "I want to understand X" request into a structured deep-dive. It targets a curious learner who wants a real working model of a concept, not just an answer — and it leans on whatever surface preferences the user has already set (language, voice, appetite for visualization). Your job here is the **method underneath**: the skill adds the four things surface preferences alone can't deliver — prerequisite mapping, layered exposition, mechanism-accurate memory hooks, and a "where to go next" trailhead.
+
+> If you're answering a quick factual question or helping with a writing/coding task, this skill is the wrong tool. Use it only when the user is asking to _understand_ something they don't yet have a working model of.
+
+## Why this skill exists
+
+A learner usually can't name their own blind spots — "you don't know what you don't know." So the most valuable thing you can do is **make the unknown unknowns visible** — show the territory before walking through it, surface the prerequisites that other explanations silently assume, and connect the concept being asked about to neighbors the user might not realize were relevant.
+
+Three principles run underneath everything below:
+
+1. **Map before walk.** A learner who can see the territory recovers faster from confusion than one who can only see the next step. Always sketch the landscape first.
+2. **Mechanism > surface similarity.** An analogy that _looks_ like the target but uses a different mechanism teaches a false model. If you reach for an analogy, verify it shares the actual causal mechanism, not just the visual outcome. (Example: lift, thrust, and buoyancy all "make things go up" but are entirely different mechanisms; don't pool them.)
+3. **Leave a trail, not a destination.** End every deep-dive with concrete next steps so the learning compounds instead of ending in a cul-de-sac.
+
+## The workflow
+
+Treat the following as **elements that must appear somewhere** in your response, not as a rigid template. Order and weight depend on the topic. A history question might foreground the timeline; a physics derivation might foreground the mechanism; a CS framework might foreground hands-on use. Use judgment.
+
+### 1. The big picture (where does this sit?)
+
+Before diving into the concept itself, situate it. Two or three sentences answering:
+
+- **What family does it belong to?** ("Diffusion models are a class of generative models, alongside GANs and VAEs.")
+- **What problem was it invented to solve?** ("Diffusion models came from modeling generation as the reverse of a gradual noising process — an idea rooted in nonequilibrium thermodynamics, Sohl-Dickstein et al. 2015 — not as a fix for GANs.")
+- **Who and when?** Name the key people and the era — historical context and the human story (人物故事) make a concept stick. Don't manufacture drama; do mention the actual humans and the actual moment. → When this human/historical story genuinely carries the concept, narrate it with the craft in [references/storytelling.md](references/storytelling.md).
+
+If the topic is purely procedural ("how do I use Polars"), the big-picture can be one sentence on what makes Polars distinct from pandas and why someone built it that way.
+
+### 2. Prerequisite check (knowledge map)
+
+List the 2–5 concepts whose comfort level meaningfully changes how you'd explain this one. Then **ask** which of them need filling in first. This isn't Socratic quizzing (don't quiz unless the user asked for it); it's a quick calibration so you don't waste paragraphs on what they already know or skip over what they don't.
+
+Format example:
+
+> 要把这块讲清楚，最好你已经熟悉：
+>
+> - **A** — 你之前 ... 熟吗？
+> - **B** — 这是 ... 的概念，熟吗？
+> - **C** — ... 熟吗？
+>
+> 哪个不熟我先补；都熟我就直接讲主线。
+
+If the topic genuinely has no prerequisites, skip this step — don't manufacture them.
+
+### 3. Main exposition (layered)
+
+Walk through the concept in **three layers**, in this order:
+
+- **Intuition** — the cleanest mental model. Use one sentence, then unpack it. No formalism yet. ("Backpropagation is just the chain rule applied to a computation graph, working right-to-left.")
+- **Mechanism** — _how_ it actually works, with enough detail to predict its behavior in a new situation. This is where the formalism, equations, code, or step-by-step process lives.
+- **Edge / limits** — where does it break, what doesn't it cover, what's the next concept that handles the gap?
+
+If the user is learning in a second language, apply the bilingual convention throughout: pair technical terms across both languages on first mention (e.g., "梯度下降 (gradient descent)") and gloss uncommon vocabulary. The reference's running example is a native Chinese speaker learning English — adapt it to the user's actual language pair. For details on format, see [references/bilingual-conventions.md](references/bilingual-conventions.md).
+
+### 4. Memory hooks
+
+At least one analogy, mnemonic, or story that makes the core mechanism stick. **Verify it shares the actual mechanism** — if you have to caveat the analogy in three places to make it correct, find a better one.
+
+Memory hooks come in flavors; pick the one that fits the concept's shape:
+
+- **Analogies** — for mechanisms (use when the target has a familiar mechanical twin)
+- **Mnemonics / 口诀** — for ordered lists or named entities (the planets, the layers of OSI)
+- **Stories** — for processes that unfold over time (the invention of calculus, why TCP looks the way it does). → When the story is real history or people, narrate it with the craft in [references/storytelling.md](references/storytelling.md).
+- **Concrete numbers** — for scales that defy intuition (a neuron fires ~200 times/sec; a CPU clock is ~3×10⁹/sec — 7 orders of magnitude)
+
+See [references/memory-hooks-patterns.md](references/memory-hooks-patterns.md) for worked examples and common traps.
+
+### 5. Visualization
+
+Pick the right visual for the content. A visual must carry information you _can't_ convey as efficiently in prose — if a sentence does the job, don't draw. Quick rules, in roughly increasing cost. The always-available primitives are **Mermaid**, **static SVG**, **Markdown tables**, and prose; the back-ticked entries below (`show_widget`, `data:create-viz`, `algorithmic-art`, `canvas-design`, `web-artifacts-builder`, `create_artifact`) name **optional artifact/widget capabilities that depend on the host environment** — use them when available, and fall back to a primitive (or describe-then-link) when not.
+
+- **Mermaid** — relationships, hierarchies, state machines, processes
+- **`show_widget`** _(if available)_ — single-panel interactive demo (one slider → one effect), or static SVG (force diagrams, geometry, anatomy); fall back to static SVG/Mermaid
+- **Markdown table** — comparing 3+ things across 3+ axes
+- **Number callout + comparison** — when magnitude itself is the point
+- **`data:create-viz`** _(if available)_ — real data → publication-quality chart
+- **`algorithmic-art` (p5.js)** _(if available)_ — **dynamic systems**: emergence, chaos, percolation, cellular automata, flocking, gradient descent on a loss surface. The single biggest unlock for STEM teaching; reach for it whenever the concept IS evolution / local rules / randomness.
+- **`canvas-design`** _(if available)_ — printable concept poster / cheat sheet
+- **`web-artifacts-builder`** _(if available)_ — complex multi-panel interactive demo with state (overkill for single widgets)
+- **`create_artifact`** _(if available)_ — when the artifact should outlive the chat turn
+
+For products / physical objects, include a real image — reach for image search or generation rather than describing in words.
+
+These rules cover the vast majority of cases. Only consult [references/visualization-playbook.md](references/visualization-playbook.md) when you're on the boundary between two tools — it has the full decision matrix, a 9-step triage, and worked decisions for edge cases.
+
+### 6. Connect the dots
+
+One short paragraph at the end: what _adjacent_ concepts does this unlock or relate to? Where does this fit in the broader map? This is the "I don't know what I don't know" remedy — surface 2–4 neighbors so the user sees what's nearby even if they don't pursue them now. → When connecting the dots becomes a narrative that ties several threads into one picture, narrate it with the craft in [references/storytelling.md](references/storytelling.md).
+
+Format example:
+
+> 这块往外延伸有几条线：
+>
+> - 想理解 X 怎么演化到 Y，下一步看 ...
+> - 同一时代的另一条思路是 ...
+> - 工程上的对应实现是 ...
+
+### 7. Trailhead (next steps)
+
+End with concrete next steps the user can actually take:
+
+- **Read** — a specific paper, chapter, blog post, or textbook section (use real, verifiable references; if you're not sure, say so)
+- **Try** — a small experiment, code snippet, calculation, or thought experiment that tests understanding
+- **Watch / interact** — a known good video, demo, or sandbox if one exists
+
+Two to four items is plenty. Don't pad. If you cite something, the citation must be checkable.
+
+## What to skip
+
+A response using this skill is going to be **long**. To keep it from sprawling, ruthlessly skip:
+
+- Recap of what the user just asked
+- Hedging like "this is a great question" or "as you may know"
+- Restating the same thing in two different ways for emphasis
+- "Hopefully this helps! Let me know if you have any questions!" closers — they add nothing; cut them
+- Markdown overhead that doesn't add structure (don't bold every other word; don't bullet single sentences)
+
+## Format choices
+
+- **Headings**: use H2 (`##`) for the main sections, H3 (`###`) only when a section has clearly separable subsections. Don't nest deeper.
+- **Bilingual STEM terms**: first mention with both languages — `反向传播 (backpropagation)` — subsequent mentions can use either.
+- **Uncommon English words**: brief Chinese in parens — `it's a chimera (奇美拉, 嵌合体) of two architectures`.
+- **Code / math**: use code blocks for code, LaTeX (`$...$` inline, `$$...$$` block) for math. Don't smuggle math into prose with unicode hacks.
+- **Mermaid blocks**: render with ` ```mermaid ` fence. Keep nodes to ≤ 12; if you need more, the concept probably needs two diagrams.
+
+## A worked outline (not a template, an example)
+
+For "what is backpropagation?", a response using this skill might look like:
+
+> **大图**：backpropagation 是训练神经网络的标准算法，1986 年 Rumelhart/Hinton/Williams 那篇论文让它出圈 …
+>
+> **前置**：你对（1）链式法则 chain rule，（2）梯度下降 gradient descent，（3）computation graph 这三个概念熟吗？哪个不熟我先补 …
+>
+> **主线（分层）**：
+>
+> - _直觉_：误差从输出层向输入层"倒着流"，每一层告诉前一层"你那里要往哪个方向调多少" …
+> - _机制_：[derivation with notation] …
+> - _边界_：vanishing/exploding gradient 在深网络里会让 backprop 失效 → 这是 ResNet/BatchNorm 要解决的问题 …
+>
+> **可视化**：[一个 Mermaid 图展示 forward pass vs backward pass 的方向]
+>
+> **记忆 hook**：把 computation graph 想成水管系统 — forward 是水从源头流到出口，backward 是从出口反向追溯"每根水管贡献了多少压力" …（验证：这个类比共享"线性叠加"机制 ✓）
+>
+> **顺藤摸瓜**：往前看 → automatic differentiation 是 backprop 的一般化；横着看 → forward-mode AD 是反过来的；往后看 → backpropagation through time 把它扩展到 RNN …
+>
+> **trailhead**：
+>
+> - 读：Goodfellow《Deep Learning》第 6.5 节
+> - 试：手算一个 2 层 MLP 在一个 sample 上的 backward pass，验证你的导数和 PyTorch autograd 一致
+> - 看：3Blue1Brown 的 backpropagation 那期视频
+
+That's the shape. Adjust ruthlessly for the topic at hand.
+
+## Reference files
+
+- [references/memory-hooks-patterns.md](references/memory-hooks-patterns.md) — analogies, mnemonics, stories: when to use which, and what counts as "mechanism-accurate"
+- [references/visualization-playbook.md](references/visualization-playbook.md) — decision matrix for Mermaid vs widget vs SVG vs table, with worked examples
+- [references/bilingual-conventions.md](references/bilingual-conventions.md) — format rules for Chinese/English term pairing and rephrase blocks
+- [references/storytelling.md](references/storytelling.md) — the secondary craft layer for the parts that carry a real story (人物/历史/connect-the-dots): investigative/explanatory-journalism moves for a writer working from sources, with hard fabrication guardrails

--- a/.agents/skills/deep-dive/SKILL.md
+++ b/.agents/skills/deep-dive/SKILL.md
@@ -49,6 +49,15 @@ Format example:
 
 If the topic genuinely has no prerequisites, skip this step — don't manufacture them.
 
+**Writing a standalone artifact (a published note, a doc) rather than teaching live?** Don't ask —
+there's no one to answer. Fold the prerequisite beat into prose: a short paragraph that names what helps
+and supplies it on the spot, then continue. Shape:
+
+> 这部分默认你对 **A**、**B** 有点感觉；没有也不要紧，三句话补上：A 是 …；B 是 …；有这两点就够往下读了。
+
+The calibration becomes a self-serve on-ramp instead of a question. (This is the non-interactive default
+for callers like `/note-from-issue`.)
+
 ### 3. Main exposition (layered)
 
 Walk through the concept in **three layers**, in this order:

--- a/.agents/skills/deep-dive/references/bilingual-conventions.md
+++ b/.agents/skills/deep-dive/references/bilingual-conventions.md
@@ -1,0 +1,81 @@
+# Bilingual Conventions (Chinese / English)
+
+These conventions apply when the user is learning in a second language and wants the deep-dive to support that. The running example throughout is a native Chinese speaker learning English — adapt the specifics to the user's actual language pair. There are three patterns; this file pins down the exact format so the skill produces consistent output.
+
+## The three patterns
+
+### 1. Rephrase the user's message
+
+At the **start** of every response, restate the user's message in natural idiomatic English, in a blockquote, so the user can learn from the improvement.
+
+```
+> [Idiomatic English rephrase of the user's message here]
+```
+
+Rules:
+
+- Keep the rephrase **faithful** to what the user actually asked. Don't expand scope, don't add interpretations.
+- Aim for what a native English speaker would actually say, not a literal translation.
+- If the user's message is already in idiomatic English, you can still rephrase if there's a noticeably better way; otherwise reflect it back as-is.
+- Skip the rephrase only if the user's message is purely numeric/symbolic (e.g., "1, 2, 3" or a single emoji).
+
+### 2. STEM and technical terminology — first-mention pairing
+
+When you introduce a technical term (math, physics, CS, biology, engineering, finance), give both languages on first mention:
+
+```
+反向传播 (backpropagation) ...
+gradient descent (梯度下降) ...
+```
+
+Rules:
+
+- Order: doesn't matter, but be consistent within a paragraph.
+- First mention: both languages, in parens.
+- Subsequent mentions in the same response: either language is fine — pick whichever flows better in the surrounding sentence.
+- If the field uses an acronym (CNN, GPU, REST), keep the acronym and gloss it once: "CNN (convolutional neural network, 卷积神经网络)".
+- Don't over-pair. Common terms like "computer", "data", "code" don't need pairing.
+
+### 3. Uncommon English vocabulary — Chinese gloss
+
+When you use an English word that's not in the everyday A2/B1 range, append a brief Chinese gloss in parens. Threshold: roughly C1+ academic vocabulary, idioms, or domain jargon outside the topic being taught.
+
+```
+This idea is a bit of a chimera (奇美拉, 嵌合体).
+The argument is tendentious (有偏向的) — let me explain.
+```
+
+Rules:
+
+- One or two Chinese characters / a short phrase. Don't write a full definition; the goal is recognition speed, not a dictionary entry.
+- Skip the gloss if the word is the topic being taught (e.g., when teaching about "entropy" you don't gloss "entropy" every time — that's the term you're defining).
+- Skip if the word is already a loanword in Chinese tech-speak (e.g., "API", "SDK", "framework" don't need glosses for an engineering audience).
+
+## Code, math, identifiers — never translate
+
+Don't translate code, mathematical symbols, file paths, library names, function names, or proper nouns. They stay verbatim.
+
+## Mixed paragraphs
+
+Mixing Chinese and English freely within a paragraph is fine and matches how many bilingual speakers naturally think. Default to Chinese for narrative and explanation; switch to English for technical terms, quotes, and proper nouns.
+
+```
+我们看一下 attention mechanism (注意力机制) 是怎么算的。给定 query Q、key K、value V，
+公式是 softmax(QK^T / √d_k) V。这里 √d_k 是为了把 dot product 的方差控制住,
+避免 softmax 进入 saturated (饱和) 区域。
+```
+
+## What this skill specifically should NOT do
+
+- **Don't write a Chinese-only response.** Even if the topic is purely Chinese-language (a Tang dynasty poem), include English terms for the technical concepts you reach for (poetics, prosody, scansion).
+- **Don't write an English-only response.** Even for code-heavy topics, the surrounding explanation should be in Chinese with English terms paired in.
+- **Don't gloss every word.** Glossing common vocabulary is patronizing and slows reading. Threshold is "would a literate Chinese speaker who's at B2 English have to stop and look this up?" — only then gloss.
+
+## Quick self-check
+
+Before sending, scan the response for:
+
+1. Is the rephrase blockquote at the top? ✓
+2. First-mention STEM terms paired? ✓
+3. Uncommon English words glossed? ✓
+4. No over-glossing of common words? ✓

--- a/.agents/skills/deep-dive/references/memory-hooks-patterns.md
+++ b/.agents/skills/deep-dive/references/memory-hooks-patterns.md
@@ -1,0 +1,65 @@
+# Memory Hooks — Patterns & Traps
+
+This reference exists because **a bad memory hook is worse than no memory hook**. A vivid analogy that uses the wrong mechanism teaches a false model, and the learner then has to unlearn it later. Be picky.
+
+## The mechanism-accuracy test
+
+Before you commit to an analogy, ask: **does the source share the actual causal mechanism with the target, or does it just share the visible outcome?**
+
+- ✅ "Backpropagation is like water reverse-flowing through a pipe network" — mechanism: linear superposition of contributions along edges. Pipes share that mechanism. Good.
+- ❌ "Lift, thrust, and buoyancy all make things go up" — these share the _outcome_ (upward motion) but use three entirely different mechanisms (pressure differential from airflow, momentum exchange, displaced fluid weight). Pooling them teaches that "up = one thing", which is wrong.
+- ❌ "DNA is a blueprint" — common but actively misleading. A blueprint is a static spatial map read once; DNA is closer to a recipe (sequential operations) or a computer program (with conditionals, loops, regulatory layers). The "blueprint" hook makes it harder to understand gene regulation later.
+
+When you can't find a clean mechanism match, **say so**: "I don't have a clean analogy that captures this — here's the mechanism directly, and here's the closest approximation, with these caveats."
+
+## Hook types and when to use them
+
+### Analogies — for mechanisms
+
+Use when the target has a familiar mechanical twin. The best analogies map structure to structure: source-node ↔ target-node, source-edge ↔ target-edge.
+
+**Worked example — TCP congestion control as a freeway on-ramp meter:**
+
+- Sender ↔ on-ramp meter; receiver ↔ downstream traffic; ACKs ↔ "I made it" feedback; congestion window ↔ how many cars released per cycle. Mechanism shared: closed-loop control responding to delayed feedback. ✓
+
+### Mnemonics / 口诀 — for ordered lists or named entities
+
+Use when the content is an ordered or enumerated set with no internal logic to derive from. Don't force a mnemonic on something that _does_ have internal logic — derivable structure beats memorized acronym.
+
+**Good** — OSI 7 layers: "Please Do Not Throw Sausage Pizza Away" (Physical, Data link, Network, Transport, Session, Presentation, Application). The layers don't have a derivable order; mnemonic earns its keep.
+
+**Bad** — using a mnemonic for the steps of long division. Long division _has_ internal logic; memorize the logic, not an acronym.
+
+### Stories — for processes that unfold over time
+
+Use when the concept _is_ a sequence of events with causes, or when the historical invention story illuminates the mechanism. Stories also satisfy a learner's appetite for historical context and the human story behind an idea ("历史背景 + 人物故事").
+
+**Worked example — why TCP looks the way it does:**
+Tell the ARPANET story: the early '70s assumption was "the network is reliable, hosts are dumb"; Cerf and Kahn flipped it to "network is dumb, hosts are smart" (end-to-end principle), because the network was about to become a confederation of unreliable subnetworks. That's why TCP does retransmission at the endpoints, not in the middle. The story isn't decoration — it explains the architecture.
+
+### Concrete numbers — for scales that defy intuition
+
+Use when the point is the _magnitude_ itself, and abstract numbers don't stick.
+
+**Worked example — CPU vs neuron timescales:**
+A neuron fires roughly 200 times/sec (5 ms refractory). A modern CPU clock is ~3 × 10⁹ Hz. That's 7 orders of magnitude — the CPU does in 1 second what your neuron does in ~6 months. (This anchors why "brain-inspired computing" doesn't mean "mimic timing".)
+
+## Common traps
+
+**Trap 1 — Anthropomorphizing.** "The molecule _wants_ to be at lower energy." It's a shorthand, but it builds wrong intuition (molecules don't have preferences; ensembles populate states proportional to Boltzmann weights). Use sparingly and flag when you do.
+
+**Trap 2 — Loading too much onto one analogy.** A good analogy maps one mechanism well. Trying to make the same analogy explain _also_ energy, _also_ parallelism, _also_ error handling usually fails. Use multiple analogies, each tight, rather than one stretched.
+
+**Trap 3 — Cultural opacity.** A baseball analogy is opaque to someone who doesn't follow baseball. Default to physical-world analogies (water, gears, traffic, cooking) that don't require culture-specific knowledge. If you use a culture-specific one, pick from contexts the user is likely to know (their cultural background, their profession, their domain).
+
+**Trap 4 — The "magic" hook.** "It's like magic — you put data in and answers come out." This is a refusal to teach. If you find yourself reaching for "magic", the model isn't there yet — go back to mechanism.
+
+## Self-check before you ship the hook
+
+Three questions:
+
+1. **Does it share the actual mechanism?** (If you have to caveat in 3 places, no.)
+2. **Could a learner predict a new situation using this hook?** (If the hook works only for the example you gave it, it's decoration not understanding.)
+3. **Does it teach anything wrong that has to be unlearned later?** (Blueprint-for-DNA fails this; calculus-as-rate fails it less.)
+
+If yes / yes / no — ship it. Otherwise iterate.

--- a/.agents/skills/deep-dive/references/storytelling.md
+++ b/.agents/skills/deep-dive/references/storytelling.md
@@ -1,0 +1,126 @@
+# Storytelling Overlay — narrating the narrative parts
+
+This is the **secondary** craft layer for a deep-dive: the pedagogical method in `SKILL.md` is the
+spine, and you reach for this file only where a part of the topic genuinely *carries a story* — the real
+human story (人物故事), the historical arc of a discovery (历史故事), or the connect-the-dots that links
+several threads into one picture. It is the craft of deep, investigative/explanatory journalism, adapted
+for a writer who works **from sources, not from first-hand reporting**.
+
+Use it on a section, not the whole piece. A definitional explainer or a how-to needs no story — forcing
+one manufactures false stakes (see guardrails). When the material *is* story-shaped, this layer makes it
+grip.
+
+## The one principle: keep the skeleton, swap the camera for the citation
+
+The grip of great explanatory/investigative journalism is **engineering, not ineffable voice**. (Ed
+Yong: "99 percent of writing problems are actually structuring problems… most of the techniques are
+fairly obvious on the page and easy to reverse-engineer.") The high-leverage devices all operate on
+**verifiable ideas, history, numbers, and published claims** — so they are simultaneously high-impact
+*and* low fabrication-risk. The drama comes from the **architecture of the explanation** and from **real
+disagreements between people and ideas**, never from invented atmosphere.
+
+Operating rule: any device that wants a concrete particular must be fed a **sourced** one — a date, a
+named person doing a documented thing, a measured number, a real verbatim quote. When no sourced
+concrete exists, **drop one rung to honest summary rather than invent.** A reporter earns scene and
+texture first-hand; you do not have that, so you trade the camera for the citation. (This is the same
+discipline as the mechanism-accuracy test for analogies in `memory-hooks-patterns.md` — never let a
+vivid surface stand in for a verified mechanism.)
+
+## Safe narrative moves — the palette
+
+Pick what fits the part. These are the moves that survive the no-first-hand-reporting constraint.
+
+- **Surprising-fact / vivid-summary lead** — open the section on a real, cited, counterintuitive fact.
+  The default safe hook. (The cancer-screening note's "a screening that looked like a miracle was a
+  statistical illusion" is this move.)
+- **Intuition-reframe** — name the reader's naive model in one line, then overturn it. ("It's intuitive
+  to think antibodies protect you — but immunology is where intuition goes to die.") Reproducible from
+  verifiable claims; conveys nuance instead of false certainty.
+- **Conflict-of-ideas / discovery-as-narrative** — make the *question* the protagonist, not a person
+  whose feelings you'd have to imagine. Sequence the real intellectual history: the old/intuitive view →
+  the crack that broke it → the contending hypotheses → the decisive evidence → what is still open. Every
+  beat is a documented position, date, or paper. The withheld answer supplies the suspense.
+- **Ladder of abstraction** (shared with the spine) — open a narrative section on the concrete particular,
+  earn the abstraction, then oscillate. Concrete-first is also fabrication-safe when the concrete is
+  sourced.
+- **Full-circle kicker** — close the loop on the opening image with a single held-back, cited fact. The
+  reserved "gold coin" lands hardest at the end.
+- **Honest-uncertainty ending on a real open question** — end on a question *the field itself* has not
+  answered, with the uncertainty attributed. This is the genuine version of "leaving suspense." (The
+  swiss-verein note's "the biggest variable in the next decade may hide in the tightening tension between
+  Swiss arbitration and EU law" is this move.)
+- **Gold coins + section transitions** — seed cited, counterintuitive facts (a scale comparison, a named
+  first/record) to pull the reader forward. **Bright line:** a section may end on an open question *only
+  if the next section answers it from a source*; never end on withholding a fact you already have (that is
+  a manufactured cliffhanger — see guardrails).
+
+## Structural templates — when a whole note is story-shaped
+
+If the topic (not just a section) is a story, pick a shape:
+
+- **Explainer** (question → answer → why-it-matters) — the *default* for an abstract "what is X / why
+  now" topic with no real anecdote; near-zero fabrication temptation. Often you want this and only a
+  *touch* of the moves above.
+- **Discovery / conflict-of-ideas arc** (complication → developments → resolution) — a real documented
+  dispute or the history of a discovery.
+- **WSJ feature** (sourced specific → nut graf → body → full-circle kicker) — when a real, citable
+  concrete instance exists to open on. The opening specific must be lifted from a source; if none exists,
+  fall back to the surprising-fact lead.
+- **Follow-one-thread / object's journey** — trace a sprawling system (a supply chain, a metabolic
+  pathway, the internet) through one real representative entity.
+- **Hourglass** (top-line facts → turn → chronological narrative) — serves skimmers and engaged readers
+  at once when there's both a bottom line and a story worth telling in order.
+- **Problem → solution** — "how are people tackling X"; avoid both doom-only and hype-only.
+
+## Hard guardrails — the final self-audit gate
+
+Run this list against the finished draft. **Any hit blocks publish.** These exist because the failure
+modes of "narrative" writing are exactly the moves a sourced writer must not make.
+
+- **No invented scenes / sensory color / 五感白描** over unsourced detail (weather, gestures, mood, "you
+  can almost smell it"). Absent sourced sensory detail → honest summary ("they worked in a poorly
+  ventilated shed"), not a manufactured scene.
+- **No reconstructed dialogue or inner monologue** ("she must have felt…", "he thought…"). Only verbatim,
+  attributable quotes from published interviews / talks / papers. If a person's words or motive can't be
+  sourced, fall back to the discovery arc.
+- **No composite / "everyman" characters** ("想象一下武汉的张医生那天早上…"). Only real, documented
+  carriers (a named case, a specific study, a real object); if none exists, use an analogy instead.
+- **No manufactured cliffhanger** that withholds a known answer ("但接下来发生的事改变了一切"). Allowed
+  only: questions the *field* has not answered, attributed. Test: *do I actually know the answer I'm
+  hiding?* If yes, reveal it or end elsewhere.
+- **No purple prose / evaluative adjectives** (惊人地, 触目惊心, 令人发指) doing the work a cited number
+  should do. Cut the adjective, supply the figure; let the restrained register carry the weight.
+- **No vague / unquantified stakes** ("this changes everything"); **no question lead as a crutch** ("你有
+  没有想过…"); **no false-summary / forced-moral tail** ("这告诉我们…", "归根结底…"). The prior concrete
+  or open beat is the true kicker — delete the explainer-of-the-meaning sentence.
+- **No analogy that smuggles a false implication** (agentive/teleological framing the sources don't
+  support; an un-fenced metaphor readers over-extend). Mark where the metaphor breaks; one analogy per
+  concept.
+
+### When writing from sources / for publication
+
+These are the rules most specific to building a note from web research — and citation integrity is the
+**single most likely fabrication vector for an LLM**, more so than invented scenes.
+
+- **Citation integrity.** Cite **only sources you actually retrieved this session.** Never invent a DOI,
+  a date, a "2021 study," or attach a real author to a claim they did not make. Quote **verbatim** from
+  the fetched text; when you translate a quote, **preserve the original-language quote alongside** the
+  translation. No figure appears in the body without a session-retrieved source behind it, and **every
+  body figure maps to a 来源/Methods entry** (no orphans).
+- **Evidence tiering.** Not all citations are equal: peer-reviewed > preprint > reputable outlet > press
+  release / blog. Prefer reviews / meta-analyses for any "consensus" claim; explicitly flag preliminary,
+  single-study, or industry-funded claims.
+- **Source disagreement.** When sources conflict on a fact, report the spread and attribute each side —
+  don't silently pick one or average them.
+- **Numeracy sanity.** For any "concretize the scale" comparison (e.g. "150 MW ≈ 120,000 households"),
+  show the arithmetic, cite both inputs, and sanity-check the order of magnitude before publishing.
+- **When NOT to dramatize.** If the section's one-sentence theme has no real stakes, write it plainly and
+  say so. Don't inflate false stakes onto a mundane topic; the gravity of "narrative" pulls that way.
+
+## What good looks like
+
+The strongest existing notes already do this without naming it: the cancer-screening note opens
+surprising-fact + intuition-reframe and ends on what evidence still can't settle; the chips note is a
+pure conflict-of-ideas ("everyone self-designs — yet they all flow through one fab"); the swiss-verein
+note closes on a genuine, attributed open question. If a strong note seems to "violate" a rule here, the
+rule is wrong — fix the rule, not the note.

--- a/.agents/skills/deep-dive/references/visualization-playbook.md
+++ b/.agents/skills/deep-dive/references/visualization-playbook.md
@@ -1,0 +1,71 @@
+# Visualization Playbook
+
+Reference material for picking the right visualization tool. The SKILL.md body already lists the tools and their primary uses; **consult this file only when you're on the boundary between two tools** and need the decision matrix, the worked decisions, or the anti-patterns.
+
+A visual must carry information **more efficiently** than prose. If a sentence does the job, don't draw.
+
+## Decision matrix
+
+| Content shape                                                                                                                                         | Use                             | Tier       |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ---------- |
+| Relationships / hierarchy / process flow / state machine / sequence                                                                                   | **Mermaid**                     | built-in   |
+| Comparison across ≥3 items × ≥3 attributes                                                                                                            | **Markdown table**              | built-in   |
+| Magnitude / scale that defies intuition                                                                                                               | **Number callout + comparison** | built-in   |
+| Real-world product / physical object                                                                                                                  | **Image** (search or generate)  | built-in   |
+| Single-panel interactive demo, one slider → one effect                                                                                                | **`show_widget`**               | built-in   |
+| Static SVG (force diagram, geometry, anatomy)                                                                                                         | **`show_widget`** with SVG      | built-in   |
+| Real data → publication-quality chart                                                                                                                 | **`data:create-viz`**           | skill      |
+| **Dynamic system / emergence / "watch it run"** (cellular automata, chaos, percolation, flocking, random processes, gradient descent on loss surface) | **`algorithmic-art`** (p5.js)   | skill      |
+| Printable concept poster / cheat sheet (one static image)                                                                                             | **`canvas-design`**             | skill      |
+| Complex multi-panel interactive demo with state and real components                                                                                   | **`web-artifacts-builder`**     | skill      |
+| Artifact the user will re-open across sessions / refresh on demand                                                                                    | **`create_artifact`**           | persistent |
+
+## 9-step triage
+
+When in doubt, walk down this list and stop at the first match:
+
+1. **Is one sentence enough?** → write the sentence. No visual.
+2. **Relationship / process I can draw with ≤ 12 nodes?** → Mermaid.
+3. **Single static image (force diagram, geometry, anatomy)?** → SVG via `show_widget`.
+4. **Concept fundamentally dynamic — emerges over time / from rules / from randomness?** → `algorithmic-art`.
+5. **Real data + real chart needed?** → `data:create-viz`.
+6. **One slider → one visual?** → interactive `show_widget`.
+7. **Multiple panels, lots of state, real components?** → `web-artifacts-builder`.
+8. **Printable cheat sheet / poster?** → `canvas-design`.
+9. **Should this outlive the chat turn?** → wrap in `create_artifact`.
+
+## Worked decisions (representative)
+
+**"Why does percolation have a sharp phase transition?"**
+→ `algorithmic-art` with a slider for occupation probability _p_, N×N grid with flood-fill coloring connected clusters. The user moves _p_ from 0.4 → 0.7 and **sees** the giant cluster pop into existence around p_c ≈ 0.5927. This is the canonical p5 case — no prose can deliver that "aha".
+
+**"Explain how a transformer works."**
+→ Mermaid `flowchart LR` for the token → embedding → [attention → add&norm → FFN] × N stack. Second Mermaid for Q/K/V. No interactivity needed — the architecture is static.
+
+**"What does the normal distribution look like as σ changes?"**
+→ `show_widget` with one slider, redrawing the PDF. Fits a single panel; perfect fit.
+
+**"Compare Postgres, MySQL, and SQLite for a small read-heavy app."**
+→ Markdown table — 3 items × 6 attributes.
+
+**"Give me a one-pager I can print covering organic chemistry functional groups."**
+→ `canvas-design` — printable .png/.pdf, the whole point is one static image.
+
+## Anti-patterns
+
+- **Pie charts for >5 slices** — humans can't compare angles. Use a bar chart.
+- **3D charts** — almost never warranted; the third dimension distorts data.
+- **Color-only encoding** — pair with shape/pattern/label for accessibility.
+- **A diagram that just restates the bullet list above it** — pick one.
+- **Decoration emoji** — they add noise, not information; skip them.
+- **Reaching for `web-artifacts-builder` when `show_widget` would do** — heavier and slower for the same outcome.
+- **`create_artifact` for one-off explanations** — persistence has overhead; only worth it when re-opens are likely.
+- **Animating something static** — `algorithmic-art` is great when dynamics carry information; otherwise animation just delays comprehension.
+
+## Tool-specific notes (compact)
+
+- **Mermaid**: ≤ 12 nodes per diagram; split if more. Always set `direction` (LR for process, TD for hierarchy). One accent color, not rainbow.
+- **`show_widget`**: single self-contained HTML/SVG. If you need multiple coordinated panels, upgrade to `web-artifacts-builder`.
+- **`algorithmic-art`**: STEM sweet spots — cellular automata (Game of Life, Rule 30), chaos (Lorenz, double pendulum, logistic map), emergence (boids, Vicsek), phase transitions (percolation, Ising, forest fire), random processes (random walks, Galton board), optimization (simulated annealing, gradient descent), neural dynamics, wave/fluid sim.
+- **`canvas-design`**: outputs .png/.pdf files — deliverable, not inline visual.
+- **`create_artifact`**: HTML in browser only. Can embed Mermaid, Chart.js, Grid.js. Compose with other tools rather than replacing them.

--- a/.claude/commands/note-from-issue.md
+++ b/.claude/commands/note-from-issue.md
@@ -92,7 +92,7 @@ lark-cli im +messages-send --as bot --user-id ou_b196a9da09c0f5dce927256299ebdba
    因合并会先 close）。在途的先走「恢复」。两者都空则本轮结束（什么都别建别提交别评论别通知）。
 2. **认领** — 打 `note-in-progress` 占位防重；把 issue JSON 存到 `.note-intake/issue-<n>.json`
    （即红线②的不可信数据文件）。
-3. **研究 + 撰写 + 自检（Workflow）** — 按 §目标 检索研究、构思结构 → 起草 note → 对抗式核查：事实准确·可溯源、写作合 deep-dive 法
+3. **研究 + 撰写 + 自检（Workflow）** — 按 §目标 检索研究、构思结构 → 起草 note → 对抗式核查：事实准确·可溯源、写作符合 deep-dive 法
    （分层科普 + 叙事处用 storytelling、读者校准 audience-aware-comms；叙事处守防杜撰 / 引用完整性）、移动端响应式与触控可用性、成品洁度（无元注释 / 过程残留）、防杜撰 / 防注入 / 查 schema /
    约定 / 排版 →
    不过则修订重核，≤2 轮。约定的唯一来源：

--- a/.claude/commands/note-from-issue.md
+++ b/.claude/commands/note-from-issue.md
@@ -23,9 +23,16 @@ argument-hint: "(无参数；配合 /loop 5m /note-from-issue 使用)"
   炫技，够用就停在最轻的层。
 - **移动优先**：站点读者以移动端为主，文章与可视化组件一律 mobile-first——响应式布局、触控目标够大、
   小屏不横向溢出、不依赖 hover、窄视口下优雅降级；产出后在窄视口自检一遍。
-- **写作风格**：遵循 Scott Adams《The Day You Became a Better Writer》（本站 note
-  `/notes/the-day-you-became-a-better-writer-20070616`）——**简单即说服力**：删冗词、写短句、
-  主谓宾语序、第一句就抓住读者；够清楚就停笔。
+- **写作风格**：以项目内 skill **`deep-dive`** 为主干——大图（含真实人物 / 历史）→ 自助补齐前置 →
+  分层讲解（直觉 → 机制 → 边界）→ 机制准确的记忆钩子 → 可视化 → 顺藤摸瓜 → trailhead；用
+  **`audience-aware-comms`** 建模读者（首次接触该主题、移动端、好奇但不熟）。**笔记是独立发布的成品、
+  非互动教学**，故对 deep-dive 做两处改写：① 不复述读者消息、不向读者发问，前置知识在文内自助补齐；
+  ② 可视化 / 术语外文 / 中文排版 / 移动优先一律以本文其余条款与 design system、AGENTS.md 为准，覆盖
+  deep-dive 自带的通用 playbook（只保留它「图要胜过文字、一图一结论」等判断原则）。凡涉及真实历史 /
+  人物 / connect-the-dots 等适合叙事处，按 deep-dive 的 `references/storytelling.md`（深度调研 / 探索类
+  新闻手法）展开：keep the skeleton, swap the camera for the citation——只用可溯源的具体细节，安全开头
+  （反常事实 / 直觉反转 / 思想之争），结尾落在该领域真实的开放问题；叙事处死守防杜撰与引用完整性红线
+  （不虚构场景 / 对话 / 五感；只引本轮检索到的来源、原文照引、译文保留原文；不造悬念噱头）。
 - **术语与外文**：专有名词（产品 / 品牌 / 人名 / 技术名，如 GitHub、Astro、oklch）一律保留英文原文、
   不强译；**例外有二**：① 中文本名的公司 / 机构（台积电、联发科、华大九天等）保留中文，首次出现时在括号
   内补英文，如 `台积电（TSMC）`、`联发科（MediaTek）`；② 已为中文通用音译的人名（马斯克、库克 等）
@@ -85,8 +92,8 @@ lark-cli im +messages-send --as bot --user-id ou_b196a9da09c0f5dce927256299ebdba
    因合并会先 close）。在途的先走「恢复」。两者都空则本轮结束（什么都别建别提交别评论别通知）。
 2. **认领** — 打 `note-in-progress` 占位防重；把 issue JSON 存到 `.note-intake/issue-<n>.json`
    （即红线②的不可信数据文件）。
-3. **研究 + 撰写 + 自检（Workflow）** — 按 §目标 检索研究、构思结构 → 起草 note → 对抗式核查：事实准确·可溯源、写作风格符合
-   Scott Adams、移动端响应式与触控可用性、成品洁度（无元注释 / 过程残留）、防杜撰 / 防注入 / 查 schema /
+3. **研究 + 撰写 + 自检（Workflow）** — 按 §目标 检索研究、构思结构 → 起草 note → 对抗式核查：事实准确·可溯源、写作合 deep-dive 法
+   （分层科普 + 叙事处用 storytelling、读者校准 audience-aware-comms；叙事处守防杜撰 / 引用完整性）、移动端响应式与触控可用性、成品洁度（无元注释 / 过程残留）、防杜撰 / 防注入 / 查 schema /
    约定 / 排版 →
    不过则修订重核，≤2 轮。约定的唯一来源：
    - `AGENTS.md`：「Interactive component layers」（分层 SVG>Canvas>React、主题 token、
@@ -116,8 +123,9 @@ lark-cli im +messages-send --as bot --user-id ou_b196a9da09c0f5dce927256299ebdba
      `node <CODEX>/scripts/codex-companion.mjs review --json --scope working-tree`，结果落
      `.note-intake/codex-<n>.json`（`verdict` + `findings[].severity` ∈ critical|high|medium|low）。
      `<CODEX>` 取 `~/.claude/plugins/marketplaces/openai-codex/plugins/codex`，没有则 cache 下最新版。
-   - **同时**（不等 codex）派 agent teams 做多视角对抗评审，维度：事实准确与可溯源 / 写作风格（Scott
-     Adams：简洁·结构·开头）/ 注入与文件边界 / schema 与构建 / 中文排版与术语（英文母语专有名词保留
+   - **同时**（不等 codex）派 agent teams 做多视角对抗评审，维度：事实准确与可溯源 / 写作质量（deep-dive
+     教学结构：大图 / 自助前置 / 分层（直觉·机制·边界）/ 机制准确钩子 / 连点 / trailhead · 读者校准
+     audience-aware-comms · 叙事处的 storytelling craft 与防杜撰 / 引用完整性）/ 注入与文件边界 / schema 与构建 / 中文排版与术语（英文母语专有名词保留
      英文、中文本名公司 / 通用音译人名保留中文、生僻英文在最早出现处附中文译名）/ 移动端响应式与触控可用性
      （窄视口不溢出·触控目标·不依赖 hover）/ 成品洁度（无元注释 / 过程残留）/ 方案取舍，各视角独立。
    - 两边都回来后**汇合裁决**（这一步由你做，别塞进对抗 Workflow——否则可能在 codex 写完文件前就

--- a/.claude/skills/audience-aware-comms
+++ b/.claude/skills/audience-aware-comms
@@ -1,0 +1,1 @@
+../../.agents/skills/audience-aware-comms

--- a/.claude/skills/deep-dive
+++ b/.claude/skills/deep-dive
@@ -1,0 +1,1 @@
+../../.agents/skills/deep-dive


### PR DESCRIPTION
## What & why

Re-aims `/note-from-issue` notes away from the Scott Adams "concise-business" rule toward your **`deep-dive`** pedagogical method as the spine, with investigative/explanatory-journalism **storytelling as a *selective* overlay** for the narrative parts (人物 / 历史 / connect-the-dots), and **`audience-aware-comms`** for reader modeling. The strongest recent notes already write this way — the framing doc just still said "Scott Adams," so the labeled style contradicted the actual (better) voice. This makes the doc match it, and makes the quality reproducible.

## Changes

- **Vendor two project skills** — `deep-dive` + `audience-aware-comms` symlinked into `.claude/skills/` (canonical copies in `.agents/skills/`), so the unattended loop has them version-controlled.
- **New `deep-dive/references/storytelling.md`** — the journalism craft, distilled from a multi-agent research pass (8 survey angles → synthesis → adversarial critique scoring each pattern for LLM-learnability + fabrication risk). Core principle: *keep the skeleton, swap the camera for the citation* — drama from real ideas / history / numbers, never invented scenes. Wired into deep-dive's big-picture / stories / connect-dots sections.
- **`audience-aware-comms`** — added a first-time 科普 reader profile.
- **`note-from-issue.md`** — replaced all 3 Scott Adams references (the 写作风格 mandate, the §3 self-check, the §5 adversarial-review dimension). Note-mode overrides stated once: standalone & non-interactive (self-serve prerequisites, never ask the reader), and this repo's viz / 术语 / 排版 / mobile rules supersede deep-dive's generic playbooks.
- The Scott Adams note stays a published archive — it's just no longer the style mandate.

## Worth a look

The storytelling overlay adds a **citation-integrity** guardrail (cite only sources retrieved this session, quote verbatim, keep the original-language quote) — the research flagged invented *citations* as a bigger LLM failure mode than invented scenes, so this strengthens the existing 防杜撰 red line.

## Verify

- `.claude/skills/{deep-dive,audience-aware-comms}` resolve via symlink; `references/storytelling.md` is reachable from deep-dive's SKILL.md.
- No dangling style refs: `rg 'Scott Adams|简单即说服力'` hits only the archive note.
- Back-test: the cancer-screening (surprising-fact + intuition-reframe), chips (conflict-of-ideas), and swiss-verein (honest open-question kicker) notes already exemplify the new rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
