### PR TITLE
🔧 chore(footer): point github link to krosdai org

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -7,7 +7,7 @@ import { siteConfig } from "@/site.config";
   <div class="page-shell note text-muted py-10 sm:flex-col">
     <div class="grid items-center gap-x-4 gap-y-2 sm:grid-cols-[1fr_auto_1fr]">
       <a
-        href="https://github.com/daihaus/xdanger.com"
+        href="https://github.com/krosdai/xdanger.com"
         class="focus-visible:ring-accent inline-flex items-center gap-2 justify-self-start rounded-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         aria-label={`${siteConfig.author} on GitHub (opens in a new tab)`}
         target="_blank"


### PR DESCRIPTION
## What

Update the footer GitHub link from `github.com/daihaus/xdanger.com` to `github.com/krosdai/xdanger.com`.

## Why

The repository moved to the `krosdai` org; the footer link still pointed at the old `daihaus` path. This was the only occurrence of `github.com/daihaus` in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)