### PR TITLE
🔧 chore(deps): bump `pnpm` to 11.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.2.0",
   "license": "CC-BY-SA-4.0",
   "type": "module",
-  "packageManager": "pnpm@11.6.0+sha512.9a36518224080c6fe5165afdcfe79bfa118c29be703f3f462b1e32efe1e98e47e8750b148e08286250aad4113cc7993ca413c4e2cd447752708c2ee5751bc95f",
+  "packageManager": "pnpm@11.7.0+sha512.19cc852c120c7125760f2443ee6be0ca5b40f9f50598de1a09a1f177503e010e57c23c77646e01e761de59bf874fb22a3398c33ab9691fc13eb946b6f0f4d620",
   "engines": {
     "node": ">=22.12.0",
     "pnpm": ">=11"


### PR DESCRIPTION
## Summary
- Bump the Corepack `packageManager` pin from `pnpm@11.6.0` to `pnpm@11.7.0`.
- Leave dependency ranges unchanged because `pnpm outdated` reports remaining drift as `current == wanted`.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm outdated --format json`

## Risk
- Low: package-manager pin only; no dependency ranges or lockfiles changed.
