### PR TITLE
🔧 chore(brand): rename `daihaus` to `krosdai`

### DIFF
--- a/.claude/commands/note-from-issue.md
+++ b/.claude/commands/note-from-issue.md
@@ -6,7 +6,7 @@ argument-hint: "(无参数；配合 /loop 5m /note-from-issue 使用)"
 # /note-from-issue — issue → 已发布 note（端到端 · 无人值守）
 
 把 `xdanger` 本人、带 `note-taking` label 的 GitHub issue 自动写成站点 note 并发布。
-**每次调用是一轮**，配合 `/loop 5m /note-from-issue` 使用。仓库：`daihaus/xdanger.com`。
+**每次调用是一轮**，配合 `/loop 5m /note-from-issue` 使用。仓库：`krosdai/xdanger.com`。
 
 > 执行你的也是同样聪明的 Claude——下面只给目标、红线和不可推导的事实，机械细节（具体
 > 命令、轮询、清理）你自己拿捏。

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -17,7 +17,7 @@ jobs:
       github.event.pull_request &&
       !github.event.pull_request.draft &&
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: daihaus/.github/.github/workflows/code-review.yml@v1
+    uses: krosdai/.github/.github/workflows/code-review.yml@v1
     with:
       pr_number: ${{ github.event.pull_request.number }}
       is_draft: ${{ github.event.pull_request.draft }}

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -4,7 +4,7 @@
   role="img"
   aria-labelledby="title desc"
 >
-  <title id="title">Daihaus d mark</title>
+  <title id="title">Krosdai d mark</title>
   <desc id="desc">A white lowercase d mark on a rounded red background.</desc>
 
   <rect width="512" height="512" rx="112" fill="#b02e22" />

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -85,26 +85,26 @@ const socialImageURL = new URL(ogImage ? ogImage : "/social-card.png", Astro.url
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@daihaus/lxgw-bright@2.0.0/400-normal.css"
+  href="https://cdn.jsdelivr.net/npm/@krosdai/lxgw-bright@2.0.0/400-normal.css"
   integrity="sha256-lxId3noNz56rABWEX8MBYCh5UwfFL1AAU+AD3kkK2GU="
   crossorigin="anonymous"
 />
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@daihaus/lxgw-bright@2.0.0/500-normal.css"
-  integrity="sha256-YlbnU65CSPbaj4UlabV9sD5lCwGTj44pDw5rDhrP4RI="
+  href="https://cdn.jsdelivr.net/npm/@krosdai/lxgw-bright@2.0.0/500-normal.css"
+  integrity="sha256-g2OSTzmhr+SYMhzoDvf6CSawUlhyvJYg39lUr0jVDgU="
   crossorigin="anonymous"
 />
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@daihaus/lxgw-bright@2.0.0/400-italic.css"
+  href="https://cdn.jsdelivr.net/npm/@krosdai/lxgw-bright@2.0.0/400-italic.css"
   integrity="sha256-98jvZlYo07QTQgbt5qYAMdXtFQ9MToBfVJSdHJOD0ls="
   crossorigin="anonymous"
 />
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@daihaus/lxgw-bright@2.0.0/500-italic.css"
-  integrity="sha256-gIH09UXnBVFEm6X7iwLDkg1bc06zrbfUdActTwT5TJ4="
+  href="https://cdn.jsdelivr.net/npm/@krosdai/lxgw-bright@2.0.0/500-italic.css"
+  integrity="sha256-HAxpEI/WYRZuFSu8Af2SbkL0vH5Ve0pvgHeUQDWXfJo="
   crossorigin="anonymous"
 />
 


### PR DESCRIPTION
Renames every `daihaus` reference to `krosdai` following the GitHub org rename (remote is now `krosdai/xdanger.com`).

## Changes
- **`src/components/BaseHead.astro`** — 4 LXGW Bright font CDN links `@daihaus/lxgw-bright` → `@krosdai/lxgw-bright`. The two **500-weight** SRI `integrity` hashes were also refreshed: `@krosdai` republished those CSS bundles with re-subset woff2 chunks, so the old hashes would have blocked medium-weight fonts. The 400-weight CSS is byte-identical, so its hashes are unchanged.
- **`.github/workflows/code-review.yml`** — reusable-workflow ref `daihaus/.github/...@v1` → `krosdai/.github/...@v1`.
- **`public/icon.svg`** — `<title>` text `Daihaus d mark` → `Krosdai d mark`.
- **`.claude/commands/note-from-issue.md`** — repo reference `daihaus/xdanger.com` → `krosdai/xdanger.com`.

## Verification
- Confirmed `@krosdai/lxgw-bright@2.0.0` is published on npm and all four CDN CSS URLs return HTTP 200.
- Recomputed sha256 SRI for all four CSS files against live CDN content; updated the two that changed, left the two that matched.
- Confirmed `krosdai/.github` hosts `code-review.yml` at `@v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo7kexyLwUK5H3vmQ8AQGE

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Renames project and organization references from `daihaus` to `krosdai`.
- Updates LXGW Bright CDN package URLs and refreshed medium-weight stylesheet SRI hashes.
- Points the reusable code review workflow at the renamed `krosdai/.github` repository.
- Updates brand text in the SVG icon title and Claude command repo reference.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the changes are limited to brand/reference updates and stylesheet integrity metadata.

The touched files are narrow in scope, and the package URLs, stylesheet hashes, and reusable workflow location were checked against their intended renamed targets.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the base commit contained four @daihaus/lxgw-bright URLs and that all returned 200 OK with SRI matched, and that the head commit contained four @krosdai/lxgw-bright URLs with the same successful results; no head contract mismatch was demonstrated.
- Verified that the base workflow reference uses daihaus/.github/.github/workflows/code-review.yml@v1 and returns HTTP/2 200 for both the API and the raw GET, while the head workflow reference uses krosdai/.github/.github/workflows/code-review.yml@v1 and also returns HTTP/2 200 with the workflow body preview.
- Compared brand-strings before and after artifacts, confirming old references in the base were replaced in head with zero daihaus occurrences and the expected krosdai replacements, and that the after-contract results show no\_daihaus\_in\_changed\_files True and missing\_expected\_replacements\[\].

<a href="https://app.greptile.com/trex/runs/11694803/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["🔧 chore(brand): rename \`daihaus\` to \`kr..."](https://github.com/krosdai/xdanger.com/commit/d6d1e5789a412d7e272ea149d25bc2d93d8e8b99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38762220)</sub>

<!-- /greptile_comment -->