### PR TITLE
🐛 fix(deps): patch transitive yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   esbuild: ^0.28.1
   undici: 7.28.0
   tar: 7.5.16
-  yaml: ^2.8.3
+  yaml: 2.9.0
 
 importers:
 
@@ -3905,7 +3905,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.8.3
+      yaml: 2.9.0
     peerDependenciesMeta:
       '@types/node':
         optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   esbuild: ^0.28.1
   undici: 7.28.0
   tar: 7.5.16
+  yaml: ^2.8.3
 
 importers:
 
@@ -3904,7 +3905,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -4083,11 +4084,6 @@ packages:
 
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
-    hasBin: true
-
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
     hasBin: true
 
   yaml@2.9.0:
@@ -8405,9 +8401,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
-      yaml: 2.7.1
-
-  yaml@2.7.1: {}
+      yaml: 2.9.0
 
   yaml@2.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,4 +9,4 @@ overrides:
   esbuild: ^0.28.1
   undici: 7.28.0
   tar: 7.5.16
-  yaml: ^2.8.3
+  yaml: 2.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,4 @@ overrides:
   esbuild: ^0.28.1
   undici: 7.28.0
   tar: 7.5.16
+  yaml: ^2.8.3


### PR DESCRIPTION
## Summary
- add a PNPM workspace override for `yaml` so the vulnerable `@astrojs/check -> yaml-language-server` path resolves to the existing patched `yaml@2.9.0`
- refresh `pnpm-lock.yaml` to remove `yaml@2.7.1`

## Validation
- `npm exec --yes pnpm@11.7.0 -- audit --audit-level low --json` -> 0 advisories
- `npm exec --yes pnpm@11.7.0 -- exec prettier --check pnpm-workspace.yaml pnpm-lock.yaml`
- `npm exec --yes pnpm@11.7.0 -- run build`

## Notes
- `npm exec --yes pnpm@11.7.0 -- run lint` still fails on pre-existing `oxfmt --check` output for `scripts/ensure-autocorrect-native.mjs`; this PR does not modify that file.

No direct dependency ranges were widened.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Adds a PNPM workspace override for `yaml@2.9.0`.
- Refreshes `pnpm-lock.yaml` so transitive consumers, including the `@astrojs/check` / `yaml-language-server` path, resolve to the patched `yaml` version.
- Removes the older `yaml@2.7.1` lockfile resolution.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The dependency override and lockfile refresh are narrow and merge-safe.

The change is limited to PNPM workspace dependency resolution and there are no code-path behavior changes or review findings.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Base proof run showed yaml-language-server depended on yaml@2.7.1 and audit reported GHSA-48c2-rrv3-qjmp.
- Head proof run showed yaml-language-server depended on yaml@2.9.0 only and audit reported no advisories and 0 vulnerabilities.
- Prettier checks passed and the build exited with code 0.

<a href="https://app.greptile.com/trex/runs/11709346/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 fix(deps): pin \`yaml\` override"](https://github.com/krosdai/xdanger.com/commit/b0e8272a0b18566b8cff875d06059c108fdbee86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38786497)</sub>

<!-- /greptile_comment -->